### PR TITLE
Fix xpdl module error in moz.build

### DIFF
--- a/widget/cocoa/moz.build
+++ b/widget/cocoa/moz.build
@@ -28,8 +28,6 @@ EXPORTS.mozilla.widget += [
     "CompositorWidgetParent.h",
 ]
 
-XPIDL_MODULE = "widget_cocoa"
-
 UNIFIED_SOURCES += [
     "CocoaCompositorWidget.cpp",
     "CompositorWidgetChild.cpp",


### PR DESCRIPTION
Remove `XPIDL_MODULE` definition from `widget/cocoa/moz.build` because it was defined without corresponding `XPIDL_SOURCES`, causing a `SandboxValidationError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bebee346-85cb-44e9-97fd-ea4663be72c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bebee346-85cb-44e9-97fd-ea4663be72c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

