### PR TITLE
fix(ci): make runtime build identity deterministic

### DIFF
--- a/.github/patches/upstream/toolkit-mozapps-update-tests-data-sharedUpdateXML.js.patch
+++ b/.github/patches/upstream/toolkit-mozapps-update-tests-data-sharedUpdateXML.js.patch
@@ -1,0 +1,56 @@
+diff --git a/toolkit/mozapps/update/tests/data/sharedUpdateXML.js b/toolkit/mozapps/update/tests/data/sharedUpdateXML.js
+--- a/toolkit/mozapps/update/tests/data/sharedUpdateXML.js
++++ b/toolkit/mozapps/update/tests/data/sharedUpdateXML.js
+@@ -354,44 +354,52 @@ function getUpdateString(aUpdateProps) {
+ function getUpdateString(aUpdateProps) {
+   let type = 'type="' + aUpdateProps.type + '" ';
+   let name = 'name="' + aUpdateProps.name + '" ';
+   let displayVersion = aUpdateProps.displayVersion
+     ? 'displayVersion="' + aUpdateProps.displayVersion + '" '
+     : "";
+   let appVersion = 'appVersion="' + aUpdateProps.appVersion + '" ';
++  let appVersion2 = aUpdateProps.appVersion2
++    ? 'appVersion2="' + aUpdateProps.appVersion2 + '" '
++    : "";
+   let platformVersion =
+     'platformVersion="' + aUpdateProps.platformVersion + '" ';
+   // Not specifying a detailsURL will cause a leak due to bug 470244
+   let detailsURL = 'detailsURL="' + aUpdateProps.detailsURL + '" ';
+   let promptWaitTime = aUpdateProps.promptWaitTime
+     ? 'promptWaitTime="' + aUpdateProps.promptWaitTime + '" '
+     : "";
+   let disableBITS = aUpdateProps.disableBITS
+     ? 'disableBITS="' + aUpdateProps.disableBITS + '" '
+     : "";
+   let disableBackgroundUpdates = aUpdateProps.disableBackgroundUpdates
+     ? 'disableBackgroundUpdates="' +
+       aUpdateProps.disableBackgroundUpdates +
+       '" '
+     : "";
+   let unsupported = aUpdateProps.unsupported ? 'unsupported="true" ' : "";
+   let custom1 = aUpdateProps.custom1 ? aUpdateProps.custom1 + " " : "";
+   let custom2 = aUpdateProps.custom2 ? aUpdateProps.custom2 + " " : "";
++  let buildID2 = aUpdateProps.buildID2
++    ? 'buildID2="' + aUpdateProps.buildID2 + '" '
++    : "";
+   let buildID = 'buildID="' + aUpdateProps.buildID + '"';
+ 
+   return (
+     "<update " +
+     type +
+     name +
+     displayVersion +
+     appVersion +
++    appVersion2 +
+     platformVersion +
+     detailsURL +
+     promptWaitTime +
+     disableBITS +
+     disableBackgroundUpdates +
+     unsupported +
+     custom1 +
+     custom2 +
++    buildID2 +
+     buildID
+   );
+ }

--- a/.github/patches/upstream/toolkit-mozapps-update-tests-unit_aus_update-updateManagerXML.js.patch
+++ b/.github/patches/upstream/toolkit-mozapps-update-tests-unit_aus_update-updateManagerXML.js.patch
@@ -1,0 +1,82 @@
+diff --git a/toolkit/mozapps/update/tests/unit_aus_update/updateManagerXML.js b/toolkit/mozapps/update/tests/unit_aus_update/updateManagerXML.js
+--- a/toolkit/mozapps/update/tests/unit_aus_update/updateManagerXML.js
++++ b/toolkit/mozapps/update/tests/unit_aus_update/updateManagerXML.js
+@@ -30,8 +30,10 @@ async function run_test() {
+     name: "New",
+     displayVersion: "version 4",
+     appVersion: "4.0",
++    appVersion2: "4.0.1",
+     platformVersion: "4.0",
+     buildID: "20070811053724",
++    buildID2: "01982f4f-7b80-7000-8000-000000000001",
+     detailsURL: "http://details1/",
+     serviceURL: "http://service1/",
+     installDate: "1238441300314",
+@@ -78,6 +80,17 @@ async function run_test() {
+ 
+   await standardInit();
+ 
++  await waitForUpdateXMLFiles();
++  const serializedUpdates = readFile(getUpdateDirFile(FILE_UPDATES_XML));
++  Assert.ok(
++    serializedUpdates.includes('appVersion2="4.0.1"'),
++    "the serialized update should contain the appVersion2 attribute"
++  );
++  Assert.ok(
++    serializedUpdates.includes('buildID2="01982f4f-7b80-7000-8000-000000000001"'),
++    "the serialized update should contain the buildID2 attribute"
++  );
++
+   Assert.ok(
+     !(await gUpdateManager.getDownloadingUpdate()),
+     "there should not be a downloading update"
+@@ -121,11 +134,21 @@ async function run_test() {
+     "4.0",
+     "the update appVersion attribute" + MSG_SHOULD_EQUAL
+   );
++  Assert.equal(
++    update.appVersion2,
++    "4.0.1",
++    "the update appVersion2 attribute" + MSG_SHOULD_EQUAL
++  );
+   Assert.equal(
+     update.buildID,
+     "20070811053724",
+     "the update buildID attribute" + MSG_SHOULD_EQUAL
+   );
++  Assert.equal(
++    update.buildID2,
++    "01982f4f-7b80-7000-8000-000000000001",
++    "the update buildID2 attribute" + MSG_SHOULD_EQUAL
++  );
+   Assert.equal(
+     update.detailsURL,
+     "http://details1/",
+@@ -526,8 +549,10 @@ async function run_test() {
+ 
+   let attrNames = [
+     "appVersion",
++    "appVersion2",
+     "platformVersion",
+     "buildID",
++    "buildID2",
+     "channel",
+     "detailsURL",
+     "displayVersion",
+@@ -569,6 +594,16 @@ async function run_test() {
+     "4.0",
+     "the platformVersion of the update should be 4.0"
+   );
++  Assert.equal(
++    updateHistory[0].appVersion2,
++    "4.0.1",
++    "the appVersion2 of the update should be 4.0.1"
++  );
++  Assert.equal(
++    updateHistory[0].buildID2,
++    "01982f4f-7b80-7000-8000-000000000001",
++    "the buildID2 of the update should be preserved"
++  );
+ 
+   executeSoon(doTestFinish);
+ }

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -18,7 +18,6 @@ name: Common Build Workflow
         description: 'Enable debug build'
         type: boolean
         required: true
-        default: true
       release:
         description: 'Enable release build'
         type: boolean
@@ -45,18 +44,51 @@ name: Common Build Workflow
         required: false
         default: ""
       MOZ_BUILD_DATE:
-        description: 'Build date override'
+        description: 'Expected 14-digit build ID (YYYYMMDDhhmmss)'
         type: string
-        required: false
-        default: ""
+        required: true
+    outputs:
+      artifact-name:
+        description: 'Name of the consolidated primary build artifact'
+        value: ${{ jobs.build.outputs.artifact-name }}
+      artifact-id:
+        description: 'GitHub artifact ID of the consolidated primary build artifact'
+        value: ${{ jobs.build.outputs.artifact-id }}
+      artifact-digest:
+        description: 'GitHub artifact digest of the consolidated primary build artifact'
+        value: ${{ jobs.build.outputs.artifact-digest }}
+      expected-build-id:
+        description: 'Validated build ID used for this build'
+        value: ${{ jobs.build.outputs.expected-build-id }}
 
 jobs:
   build:
     name: Build ${{ inputs.platform }}-${{ inputs.arch }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    outputs:
+      artifact-name: ${{ steps.build-identity.outputs.artifact-name }}
+      artifact-id: ${{ steps.upload-primary-artifact.outputs.artifact-id }}
+      artifact-digest: ${{ steps.upload-primary-artifact.outputs.artifact-digest }}
+      expected-build-id: ${{ steps.build-identity.outputs.expected-build-id }}
 
     steps:
+      - name: Validate build identity
+        id: build-identity
+        shell: bash
+        env:
+          PLATFORM: ${{ inputs.platform }}
+          ARCH: ${{ inputs.arch }}
+          MOZ_BUILD_DATE: ${{ inputs.MOZ_BUILD_DATE }}
+        run: |
+          if [[ ! "$MOZ_BUILD_DATE" =~ ^[0-9]{14}$ ]]; then
+            echo "::error::MOZ_BUILD_DATE must be exactly 14 decimal digits (YYYYMMDDhhmmss)."
+            exit 1
+          fi
+
+          echo "artifact-name=floorp-${PLATFORM}-${ARCH}-moz-artifact" >> "$GITHUB_OUTPUT"
+          echo "expected-build-id=${MOZ_BUILD_DATE}" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -141,53 +173,16 @@ jobs:
           SCCACHE_GHA_ENABLED: 'on'
           SCCACHE_MAX_FRAME_LENGTH: '1048576'
 
-      - name: Clean existing Windows artifacts
-        if: inputs.platform == 'windows'
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: |
-            floorp-windows-x86_64-moz-artifact
-            windows-x86_64-dist-host
-            windows-x86_64-application-ini
-
-      - name: Clean existing Linux x86_64 artifacts
-        if: inputs.platform == 'linux' && inputs.arch == 'x86_64'
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: |
-            floorp-linux-x86_64-moz-artifact
-            linux-x86_64-dist-host
-            linux-x86_64-application-ini
-
-      - name: Clean existing Linux aarch64 artifacts
-        if: inputs.platform == 'linux' && inputs.arch == 'aarch64'
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: |
-            floorp-linux-aarch64-moz-artifact
-            linux-aarch64-dist-host
-            linux-aarch64-application-ini
-
-      - name: Clean existing Mac artifacts
-        if: inputs.platform == 'mac'
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: |
-            floorp-mac-${{ inputs.arch }}-moz-artifact
-
       - name: Upload build artifact
+        id: upload-primary-artifact
         uses: actions/upload-artifact@v4
         with:
-          name: floorp-${{ inputs.platform }}-${{ inputs.arch }}-moz-artifact
+          name: ${{ steps.build-identity.outputs.artifact-name }}
           path: >-
-            ${{ inputs.platform == 'windows' &&
-            format('~/output/floorp-{0}-{1}-moz-artifact.zip',
-            inputs.platform, inputs.arch) ||
-            inputs.platform == 'mac' &&
-            format('~/output/floorp-{0}-{1}-moz-artifact.tar.gz',
-            inputs.platform, inputs.arch) ||
-            format('~/output/floorp-{0}-{1}-moz-artifact.tar.xz',
+            ${{ format('~/output/floorp-{0}-{1}-moz-artifact-bundle',
             inputs.platform, inputs.arch) }}
+          if-no-files-found: error
+          overwrite: true
 
       - name: Upload PGO profile generation package (Windows)
         if: >-
@@ -198,8 +193,24 @@ jobs:
         with:
           name: floorp-windows-x86_64-profile-generate-mode-package
           path: >-
-            ${{ format('~/output/floorp-{0}-{1}-moz-artifact.zip',
+            ${{ format('~/output/floorp-{0}-{1}-moz-artifact-bundle/floorp-{0}-{1}-moz-artifact.zip',
             inputs.platform, inputs.arch) }}
+          if-no-files-found: error
+          overwrite: true
+
+      - name: Upload PGO profile generation package (Linux)
+        if: >-
+          inputs.pgo_mode == 'generate' &&
+          inputs.platform == 'linux' &&
+          inputs.arch == 'x86_64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: floorp-linux-x86_64-profile-generate-mode-package
+          path: >-
+            ${{ format('~/output/floorp-{0}-{1}-moz-artifact-bundle/floorp-{0}-{1}-moz-artifact.tar.xz',
+            inputs.platform, inputs.arch) }}
+          if-no-files-found: error
+          overwrite: true
 
       - name: Upload PGO profile generation package (Mac)
         if: >-
@@ -209,19 +220,27 @@ jobs:
         with:
           name: floorp-mac-${{ inputs.arch }}-build-with-profgen
           path: >-
-            ${{ format('~/output/floorp-{0}-{1}-moz-artifact.tar.gz',
+            ${{ format('~/output/floorp-{0}-{1}-moz-artifact-bundle/floorp-{0}-{1}-moz-artifact.tar.gz',
             inputs.platform, inputs.arch) }}
+          if-no-files-found: error
+          overwrite: true
 
       - name: Upload dist/host for MAR
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.platform }}-${{ inputs.arch }}-dist-host
-          path: ${{ format('~/output/{0}-{1}-dist-host', inputs.platform, inputs.arch) }}
+          path: >-
+            ${{ format('~/output/floorp-{0}-{1}-moz-artifact-bundle/dist-host',
+            inputs.platform, inputs.arch) }}
+          if-no-files-found: error
           overwrite: true
 
       - name: Upload application.ini for MAR
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.platform }}-${{ inputs.arch }}-application-ini
-          path: ./floorp-application.ini
+          path: >-
+            ${{ format('~/output/floorp-{0}-{1}-moz-artifact-bundle/floorp-application.ini',
+            inputs.platform, inputs.arch) }}
+          if-no-files-found: error
           overwrite: true

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -4,6 +4,7 @@
 name: Daily Runtime Build
 
 permissions:
+  actions: read
   contents: write
 
 'on':
@@ -21,51 +22,86 @@ permissions:
         required: false
         type: boolean
         default: true
+      validation_only:
+        description: >-
+          Build and verify desktop artifacts without Android or publishing
+        required: false
+        type: boolean
+        default: false
+      requested_MOZ_BUILD_DATE:
+        description: >-
+          Optional 14-digit build ID assertion; the run creation time remains
+          authoritative
+        required: false
+        type: string
+        default: ''
 
 run-name: >-
   Daily Runtime Build
   ${{ github.event.inputs.pgo != 'false' && ' [PGO]' || '' }}
   ${{ github.event.inputs.debug == 'true' && ' (Debug)' || '' }}
+  ${{ inputs.validation_only && ' [Validation only]' || '' }}
 
 jobs:
+  resolve-build-context:
+    uses: ./.github/workflows/resolve-build-context.yml
+    with:
+      requested_moz_build_date: >-
+        ${{ inputs.requested_MOZ_BUILD_DATE || '' }}
+      require_run_metadata: true
+
   windows-x86_64:
     name: >-
       Windows x86_64${{ github.event.inputs.pgo != 'false' && ' [PGO]' || '' }}
+    needs: resolve-build-context
     uses: ./.github/workflows/wrapper-build-windows.yml
     secrets: inherit
     with:
       debug: ${{ github.event.inputs.debug == 'true' }}
       pgo: ${{ github.event.inputs.pgo != 'false' }}
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   linux-x86_64:
     name: >-
       Linux x86_64${{ github.event.inputs.pgo != 'false' && ' [PGO]' || '' }}
+    needs: resolve-build-context
     uses: ./.github/workflows/wrapper-build-linux.yml
     secrets: inherit
     with:
       debug: ${{ github.event.inputs.debug == 'true' }}
       pgo: ${{ github.event.inputs.pgo != 'false' }}
+      arch: x86_64
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   linux-aarch64:
     name: Linux aarch64
+    needs: resolve-build-context
     uses: ./.github/workflows/wrapper-build-linux.yml
     secrets: inherit
     with:
       debug: ${{ github.event.inputs.debug == 'true' }}
       pgo: false
       arch: aarch64
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   mac:
     name: >-
       Mac build${{ github.event.inputs.pgo != 'false' && ' [PGO]' || '' }}
+    needs: resolve-build-context
     uses: ./.github/workflows/wrapper-mac-build.yml
     secrets: inherit
     with:
       debug: ${{ github.event.inputs.debug == 'true' }}
       pgo: ${{ github.event.inputs.pgo != 'false' }}
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   android:
     name: Android build
+    if: ${{ inputs.validation_only != true }}
     uses: ./.github/workflows/wrapper-build-android.yml
     secrets: inherit
     with:
@@ -73,10 +109,319 @@ jobs:
       build_arm32: true
       build_x86_64: true
 
+  verify-windows-x86_64:
+    name: Verify Windows x86_64 runtime artifact
+    needs: windows-x86_64
+    uses: ./.github/workflows/verify-runtime-artifact.yml
+    with:
+      artifact-id: ${{ needs.windows-x86_64.outputs.artifact-id }}
+      artifact-name: ${{ needs.windows-x86_64.outputs.artifact-name }}
+      expected-build-id: ${{ needs.windows-x86_64.outputs.expected-build-id }}
+      platform: Windows
+      arch: x86_64
+      runner: windows-2025
+
+  verify-linux-x86_64:
+    name: Verify Linux x86_64 runtime artifact
+    needs: linux-x86_64
+    uses: ./.github/workflows/verify-runtime-artifact.yml
+    with:
+      artifact-id: ${{ needs.linux-x86_64.outputs.artifact-id }}
+      artifact-name: ${{ needs.linux-x86_64.outputs.artifact-name }}
+      expected-build-id: ${{ needs.linux-x86_64.outputs.expected-build-id }}
+      platform: Linux
+      arch: x86_64
+      runner: ubuntu-24.04
+
+  verify-linux-aarch64:
+    name: Verify Linux aarch64 runtime artifact
+    needs: linux-aarch64
+    uses: ./.github/workflows/verify-runtime-artifact.yml
+    with:
+      artifact-id: ${{ needs.linux-aarch64.outputs.artifact-id }}
+      artifact-name: ${{ needs.linux-aarch64.outputs.artifact-name }}
+      expected-build-id: ${{ needs.linux-aarch64.outputs.expected-build-id }}
+      platform: Linux
+      arch: aarch64
+      runner: ubuntu-24.04-arm
+
+  verify-mac-x86_64:
+    name: Verify macOS x86_64 runtime artifact
+    needs: mac
+    uses: ./.github/workflows/verify-runtime-artifact.yml
+    with:
+      artifact-id: ${{ needs.mac.outputs.artifact-id }}
+      artifact-name: ${{ needs.mac.outputs.artifact-name }}
+      expected-build-id: ${{ needs.mac.outputs.expected-build-id }}
+      platform: Darwin
+      arch: x86_64
+      runner: macos-15-intel
+
+  verify-mac-aarch64:
+    name: Verify macOS aarch64 runtime artifact
+    needs: mac
+    uses: ./.github/workflows/verify-runtime-artifact.yml
+    with:
+      artifact-id: ${{ needs.mac.outputs.artifact-id }}
+      artifact-name: ${{ needs.mac.outputs.artifact-name }}
+      expected-build-id: ${{ needs.mac.outputs.expected-build-id }}
+      platform: Darwin
+      arch: aarch64
+      runner: macos-14
+
+  aggregate-runtime-manifest-v2:
+    name: Aggregate Runtime Build Manifest v2
+    if: >-
+      ${{ inputs.validation_only == true ||
+          github.event.inputs.debug != 'true' }}
+    needs:
+      - resolve-build-context
+      - windows-x86_64
+      - linux-x86_64
+      - linux-aarch64
+      - mac
+      - verify-windows-x86_64
+      - verify-linux-x86_64
+      - verify-linux-aarch64
+      - verify-mac-x86_64
+      - verify-mac-aarch64
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-name: floorp-runtime-build-manifest-v2
+      artifact-id: ${{ steps.upload-manifest.outputs.artifact-id }}
+      artifact-digest: ${{ steps.upload-manifest.outputs.artifact-digest }}
+      expected-build-id: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
+    steps:
+      - name: Create and validate runtime-build-manifest-v2.json
+        shell: bash
+        env:
+          MANIFEST_REPOSITORY: >-
+            ${{ needs.resolve-build-context.outputs.repository }}
+          MANIFEST_HEAD_SHA: >-
+            ${{ needs.resolve-build-context.outputs.head-sha }}
+          MANIFEST_WORKFLOW_RUN_ID: >-
+            ${{ needs.resolve-build-context.outputs.workflow-run-id }}
+          MANIFEST_RUN_CREATED_AT: >-
+            ${{ needs.resolve-build-context.outputs.run-created-at }}
+          # A rerun-failed attempt can reuse successful attempt-1 resolver
+          # outputs. Manifest freshness belongs to this aggregate job attempt;
+          # the BuildID remains derived from the original run created_at.
+          MANIFEST_RUN_ATTEMPT: ${{ github.run_attempt }}
+          MANIFEST_EXPECTED_BUILD_ID: >-
+            ${{ needs.resolve-build-context.outputs.expected-build-id }}
+          WINDOWS_ARTIFACT_NAME: ${{ needs.windows-x86_64.outputs.artifact-name }}
+          WINDOWS_ARTIFACT_ID: ${{ needs.windows-x86_64.outputs.artifact-id }}
+          WINDOWS_ARTIFACT_DIGEST: >-
+            ${{ needs.windows-x86_64.outputs.artifact-digest }}
+          WINDOWS_EXPECTED_BUILD_ID: >-
+            ${{ needs.windows-x86_64.outputs.expected-build-id }}
+          LINUX_X64_ARTIFACT_NAME: ${{ needs.linux-x86_64.outputs.artifact-name }}
+          LINUX_X64_ARTIFACT_ID: ${{ needs.linux-x86_64.outputs.artifact-id }}
+          LINUX_X64_ARTIFACT_DIGEST: >-
+            ${{ needs.linux-x86_64.outputs.artifact-digest }}
+          LINUX_X64_EXPECTED_BUILD_ID: >-
+            ${{ needs.linux-x86_64.outputs.expected-build-id }}
+          LINUX_ARM64_ARTIFACT_NAME: ${{ needs.linux-aarch64.outputs.artifact-name }}
+          LINUX_ARM64_ARTIFACT_ID: ${{ needs.linux-aarch64.outputs.artifact-id }}
+          LINUX_ARM64_ARTIFACT_DIGEST: >-
+            ${{ needs.linux-aarch64.outputs.artifact-digest }}
+          LINUX_ARM64_EXPECTED_BUILD_ID: >-
+            ${{ needs.linux-aarch64.outputs.expected-build-id }}
+          MAC_ARTIFACT_NAME: ${{ needs.mac.outputs.artifact-name }}
+          MAC_ARTIFACT_ID: ${{ needs.mac.outputs.artifact-id }}
+          MAC_ARTIFACT_DIGEST: ${{ needs.mac.outputs.artifact-digest }}
+          MAC_EXPECTED_BUILD_ID: ${{ needs.mac.outputs.expected-build-id }}
+        run: |
+          set -euo pipefail
+          mkdir -p runtime-manifest
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          BUILD_ID_RE = re.compile(r"[0-9]{14}")
+          SHA_RE = re.compile(r"[0-9a-f]{40}")
+          DIGEST_RE = re.compile(r"[0-9a-f]{64}")
+
+
+          def required(name):
+              value = os.environ.get(name, "").strip()
+              if not value:
+                  raise ValueError(f"missing required value: {name}")
+              return value
+
+
+          def positive_int(name):
+              value = required(name)
+              if not re.fullmatch(r"[1-9][0-9]*", value):
+                  raise ValueError(f"{name} must be a positive decimal integer")
+              return int(value)
+
+
+          def normalize_digest(name):
+              value = required(name).lower()
+              if value.startswith("sha256:"):
+                  value = value.removeprefix("sha256:")
+              if not DIGEST_RE.fullmatch(value):
+                  raise ValueError(f"{name} must be a SHA-256 digest")
+              return f"sha256:{value}"
+
+
+          repository = required("MANIFEST_REPOSITORY")
+          if repository != required("GITHUB_REPOSITORY"):
+              raise ValueError("resolver repository does not match this workflow")
+
+          head_sha = required("MANIFEST_HEAD_SHA").lower()
+          if not SHA_RE.fullmatch(head_sha):
+              raise ValueError("MANIFEST_HEAD_SHA must be exactly 40 hex digits")
+          if head_sha != required("GITHUB_SHA").lower():
+              raise ValueError("resolver head SHA does not match this workflow")
+
+          workflow_run_id = positive_int("MANIFEST_WORKFLOW_RUN_ID")
+          if workflow_run_id != positive_int("GITHUB_RUN_ID"):
+              raise ValueError("resolver workflow run ID does not match this workflow")
+
+          run_attempt = positive_int("MANIFEST_RUN_ATTEMPT")
+          if run_attempt != positive_int("GITHUB_RUN_ATTEMPT"):
+              raise ValueError("resolver run attempt does not match this workflow")
+
+          expected_build_id = required("MANIFEST_EXPECTED_BUILD_ID")
+          if not BUILD_ID_RE.fullmatch(expected_build_id):
+              raise ValueError("expected build ID must be exactly 14 digits")
+
+          run_created_at = required("MANIFEST_RUN_CREATED_AT")
+          if not run_created_at.endswith("Z"):
+              raise ValueError("run creation time must be UTC with a Z suffix")
+          created = datetime.fromisoformat(run_created_at.replace("Z", "+00:00"))
+          if created.tzinfo is None:
+              raise ValueError("run creation time must be timezone-aware")
+          if created.astimezone(timezone.utc).strftime("%Y%m%d%H%M%S") != expected_build_id:
+              raise ValueError("run creation time does not match expected build ID")
+
+          target_specs = [
+              (
+                  "Windows",
+                  "x86_64",
+                  "floorp-windows-x86_64-moz-artifact",
+                  "WINDOWS",
+              ),
+              (
+                  "Linux",
+                  "x86_64",
+                  "floorp-linux-x86_64-moz-artifact",
+                  "LINUX_X64",
+              ),
+              (
+                  "Linux",
+                  "aarch64",
+                  "floorp-linux-aarch64-moz-artifact",
+                  "LINUX_ARM64",
+              ),
+              (
+                  "Darwin",
+                  "universal",
+                  "floorp-mac-universal-moz-artifact",
+                  "MAC",
+              ),
+          ]
+
+          targets = []
+          artifact_ids = set()
+          for platform, arch, expected_name, prefix in target_specs:
+              artifact_name = required(f"{prefix}_ARTIFACT_NAME")
+              if artifact_name != expected_name:
+                  raise ValueError(
+                      f"{platform}/{arch} artifact name mismatch: {artifact_name}"
+                  )
+
+              artifact_id = positive_int(f"{prefix}_ARTIFACT_ID")
+              if artifact_id in artifact_ids:
+                  raise ValueError(f"duplicate artifact ID: {artifact_id}")
+              artifact_ids.add(artifact_id)
+
+              target_build_id = required(f"{prefix}_EXPECTED_BUILD_ID")
+              if target_build_id != expected_build_id:
+                  raise ValueError(
+                      f"{platform}/{arch} expected build ID mismatch: {target_build_id}"
+                  )
+
+              targets.append(
+                  {
+                      "platform": platform,
+                      "arch": arch,
+                      "artifact_name": artifact_name,
+                      "artifact_id": artifact_id,
+                      "artifact_digest": normalize_digest(
+                          f"{prefix}_ARTIFACT_DIGEST"
+                      ),
+                      "expected_build_id": target_build_id,
+                  }
+              )
+
+          manifest = {
+              "schema_version": 2,
+              "repository": repository,
+              "head_sha": head_sha,
+              "workflow_run_id": workflow_run_id,
+              "run_created_at": run_created_at,
+              "run_attempt": run_attempt,
+              "expected_build_id": expected_build_id,
+              "targets": targets,
+          }
+          output = Path("runtime-manifest/runtime-build-manifest-v2.json")
+          output.write_text(
+              json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+              encoding="utf-8",
+          )
+          print(output.read_text(encoding="utf-8"), end="")
+          PY
+
+      - name: Upload Runtime Build Manifest v2
+        id: upload-manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: floorp-runtime-build-manifest-v2
+          path: runtime-manifest/runtime-build-manifest-v2.json
+          if-no-files-found: error
+          overwrite: true
+
+      - name: Summarize immutable manifest artifact
+        shell: bash
+        env:
+          MANIFEST_ARTIFACT_ID: ${{ steps.upload-manifest.outputs.artifact-id }}
+          MANIFEST_ARTIFACT_DIGEST: >-
+            ${{ steps.upload-manifest.outputs.artifact-digest }}
+          EXPECTED_BUILD_ID: >-
+            ${{ needs.resolve-build-context.outputs.expected-build-id }}
+        run: |
+          {
+            echo "### Runtime build manifest v2"
+            echo ""
+            echo "- Artifact: \`floorp-runtime-build-manifest-v2\`"
+            echo "- Artifact ID: \`${MANIFEST_ARTIFACT_ID}\`"
+            echo "- Artifact digest: \`${MANIFEST_ARTIFACT_DIGEST}\`"
+            echo "- Expected BuildID: \`${EXPECTED_BUILD_ID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   publish-debug-to-core-ftp:
     name: Publish Debug Assets to Core FTP
-    needs: [windows-x86_64, linux-x86_64, linux-aarch64, mac, android]
-    if: ${{ github.event.inputs.debug == 'true' }}
+    needs:
+      - windows-x86_64
+      - linux-x86_64
+      - linux-aarch64
+      - mac
+      - android
+      - verify-windows-x86_64
+      - verify-linux-x86_64
+      - verify-linux-aarch64
+      - verify-mac-x86_64
+      - verify-mac-aarch64
+    if: >-
+      ${{ github.event.inputs.debug == 'true' &&
+          inputs.validation_only != true }}
     runs-on: ubuntu-latest
     steps:
       - name: Download Windows x86_64 artifact
@@ -132,8 +477,10 @@ jobs:
 
   publish-release:
     name: Publish Release Assets
-    needs: [windows-x86_64, linux-x86_64, linux-aarch64, mac, android]
-    if: ${{ github.event.inputs.debug != 'true' }}
+    needs: [aggregate-runtime-manifest-v2, android]
+    if: >-
+      ${{ github.event.inputs.debug != 'true' &&
+          inputs.validation_only != true }}
     runs-on: ubuntu-latest
     steps:
       - name: Download Windows x86_64 artifact

--- a/.github/workflows/generate-pgo-profile-linux.yml
+++ b/.github/workflows/generate-pgo-profile-linux.yml
@@ -3,6 +3,10 @@
 
 name: Generate PGO Profile (Linux)
 
+permissions:
+  actions: read
+  contents: read
+
 'on':
   workflow_call:
     inputs:
@@ -21,7 +25,7 @@ name: Generate PGO Profile (Linux)
         type: string
         default: 'ubuntu-latest'
       target-arch:
-        description: 'Target architecture (x86_64, aarch64)'
+        description: 'Target architecture (x86_64 only)'
         required: false
         type: string
         default: 'x86_64'
@@ -29,12 +33,19 @@ name: Generate PGO Profile (Linux)
         description: 'Name for uploaded profile data artifact'
         required: false
         type: string
+      MOZ_BUILD_DATE:
+        description: 'Expected 14-digit Stage 1 build ID'
+        required: true
+        type: string
 
 jobs:
   generate-profdata-and-jarlog:
     name: Generate PGO Profile Data (${{ inputs.target-arch }})
     runs-on: ${{ inputs.runner }}
     env:
+      ARTIFACT_PATH: ${{ inputs.artifact-path }}
+      EXPECTED_BUILD_ID: ${{ inputs.MOZ_BUILD_DATE }}
+      TARGET_ARCH: ${{ inputs.target-arch }}
       UPLOAD_ARTIFACT_NAME: >-
         ${{ inputs.upload-artifact-name ||
         format('{0}-profile-generate-output', inputs.browser-artifact-name) }}
@@ -43,116 +54,162 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Validate PGO inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$TARGET_ARCH" != "x86_64" ]]; then
+            echo "Linux PGO profile generation only supports x86_64." >&2
+            exit 1
+          fi
+
+          if [[ ! "$EXPECTED_BUILD_ID" =~ ^[0-9]{14}$ ]]; then
+            echo "MOZ_BUILD_DATE must be exactly 14 decimal digits." >&2
+            exit 1
+          fi
+
       - name: Download browser artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.browser-artifact-name }}
-          path: ${{ inputs.artifact-path }}
-
-      - name: Set up QEMU for ARM64 (if needed)
-        if: inputs.target-arch == 'aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
+          path: ${{ env.ARTIFACT_PATH }}
 
       - name: Install dependencies
         run: |
+          set -euo pipefail
           sudo apt update -qq
-          if [[ "${{ inputs.target-arch }}" == "aarch64" ]]; then
-            # Install cross-compilation tools and ARM64 libraries
-            sudo apt install -y \
-              qemu-user-static \
-              binfmt-support \
-              gcc-aarch64-linux-gnu \
-              g++-aarch64-linux-gnu \
-              libc6-dev-arm64-cross \
-              libc6-arm64-cross \
-              xvfb \
-              mesa-utils
-
-            # Register QEMU ARM64 handler with binfmt_misc
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-
-            # Setup QEMU_LD_PREFIX for ARM64 dynamic linker
-            echo "QEMU_LD_PREFIX=/usr/aarch64-linux-gnu" >> $GITHUB_ENV
-          else
-            sudo apt install -y xvfb llvm-19 clang-19 mesa-utils
-          fi
+          sudo apt install -y xvfb llvm-19 clang-19 mesa-utils
 
       - name: Bootstrap Mozilla build
         run: |
+          set -euo pipefail
           chmod +x ./mach
-          if [[ "${{ inputs.target-arch }}" == "aarch64" ]]; then
-            # Use QEMU for ARM64 bootstrap if needed
-            ./mach --no-interactive bootstrap --application-choice browser
-          else
-            ./mach --no-interactive bootstrap --application-choice browser
-          fi
+          ./mach --no-interactive bootstrap --application-choice browser
 
       - name: Setup directories and tools
         run: |
+          set -euo pipefail
           mkdir -p obj-firefox/dist
           mkdir -p /tmp/output
           mkdir -p /tmp/clang/bin
-
-          if [[ "${{ inputs.target-arch }}" == "aarch64" ]]; then
-            # Setup ARM64 cross-compilation tools
-            # Use Docker container to get ARM64 LLVM tools
-            docker run --rm -v /tmp/clang:/tmp/clang --platform linux/arm64 ubuntu:24.04 bash -c "
-              apt update -qq &&
-              apt install -y llvm-19 &&
-              cp /usr/bin/llvm-profdata-19 /tmp/clang/llvm-profdata-arm64
-            "
-            ln -sf /tmp/clang/llvm-profdata-arm64 /tmp/clang/bin/llvm-profdata
-          else
-            ln -sf $(which llvm-profdata-19) /tmp/clang/bin/llvm-profdata
-          fi
+          ln -sf "$(command -v llvm-profdata-19)" \
+            /tmp/clang/bin/llvm-profdata
 
       - name: Extract and prepare browser
+        shell: bash
         run: |
-          cd ${{ inputs.artifact-path }}
-          
-          # Extract archive
-          if ls *.tar.* >/dev/null 2>&1; then
-            tar -xf *.tar.*
-          elif ls *.zip >/dev/null 2>&1; then
-            unzip -q *.zip
-          fi
+          set -euo pipefail
+          shopt -s nullglob
 
-          echo "Contents after extraction:"
-          ls -la
-
-          # Find browser directory - look for directories first, then check subdirectories
-          BROWSER_DIR=""
-
-          # Look for top-level directories containing browser
-          for dir in */; do
-            if [[ -d "$dir" ]]; then
-              if find "$dir" -name "floorp" -o -name "firefox" -o -name "firefox-bin" | grep -q .; then
-                BROWSER_DIR="$dir"
-                break
-              fi
-            fi
-          done
-
-          # If not found, look for any directory with floorp or firefox in name
-          if [[ -z "$BROWSER_DIR" ]]; then
-            BROWSER_DIR=$(find . -maxdepth 1 -type d \( -name "*floorp*" -o -name "*firefox*" \) | head -1)
-          fi
-
-          if [[ -n "$BROWSER_DIR" && -d "$BROWSER_DIR" ]]; then
-            echo "Found browser directory: $BROWSER_DIR"
-            mv "$BROWSER_DIR" $GITHUB_WORKSPACE/obj-firefox/dist/firefox
-          else
-            echo "Browser directory not found. Available contents:"
-            find . -type d -maxdepth 2
-            echo "Files:"
-            find . -name "*floorp*" -o -name "*firefox*"
+          archives=("$ARTIFACT_PATH"/*.tar.* "$ARTIFACT_PATH"/*.zip)
+          if (( ${#archives[@]} != 1 )); then
+            echo "Expected exactly one Stage 1 archive, found ${#archives[@]}." >&2
+            printf '  %s\n' "${archives[@]}" >&2
             exit 1
           fi
 
-      - name: Generate profile
+          archive="${archives[0]}"
+          case "$archive" in
+            *.tar.*) tar -xf "$archive" -C "$ARTIFACT_PATH" ;;
+            *.zip) unzip -q "$archive" -d "$ARTIFACT_PATH" ;;
+            *)
+              echo "Unsupported Stage 1 archive: $archive" >&2
+              exit 1
+              ;;
+          esac
+
+          mapfile -t browser_binaries < <(
+            find "$ARTIFACT_PATH" -type f -name floorp -print
+          )
+          if (( ${#browser_binaries[@]} != 1 )); then
+            echo "Expected exactly one extracted floorp binary, found ${#browser_binaries[@]}." >&2
+            printf '  %s\n' "${browser_binaries[@]}" >&2
+            exit 1
+          fi
+
+          browser_dir="$(dirname "${browser_binaries[0]}")"
+          destination="$GITHUB_WORKSPACE/obj-firefox/dist/firefox"
+          if [[ -e "$destination" ]]; then
+            echo "Browser destination already exists: $destination" >&2
+            exit 1
+          fi
+
+          mv "$browser_dir" "$destination"
+          chmod +x "$destination/floorp"
+          echo "BROWSER_PATH=$destination/floorp" >> "$GITHUB_ENV"
+
+      - name: Verify Stage 1 runtime identity natively
+        shell: bash
         run: |
+          set -euo pipefail
+
+          host_arch="$(uname -m)"
+          if [[ "$host_arch" != "x86_64" ]]; then
+            echo "The Stage 1 identity check requires an x86_64 host; got $host_arch." >&2
+            exit 1
+          fi
+
+          binary_description="$(file -b "$BROWSER_PATH")"
+          echo "Stage 1 binary: $binary_description"
+          if [[ "$binary_description" != *"x86-64"* ]]; then
+            echo "Stage 1 floorp is not a native x86_64 executable." >&2
+            exit 1
+          fi
+
+          # Exercise the packaged binary's compiled kStaticAppData. Do not
+          # permit an inherited external application.ini override.
+          unset XUL_APP_FILE
+          if full_version="$(timeout 30s "$BROWSER_PATH" --full-version 2>&1)"; then
+            :
+          else
+            status=$?
+            echo "Native floorp --full-version failed with exit code $status." >&2
+            printf '%s\n' "$full_version" >&2
+            exit "$status"
+          fi
+          printf 'floorp --full-version: %s\n' "$full_version"
+
+          build_id_pattern='(^|[^0-9])([0-9]{14})[[:space:]]+([0-9]{14})([^0-9]|$)'
+          identity_pairs=()
+          remaining="$full_version"
+          while [[ "$remaining" =~ $build_id_pattern ]]; do
+            identity_pairs+=("${BASH_REMATCH[2]} ${BASH_REMATCH[3]}")
+            matched_text="${BASH_REMATCH[0]}"
+            remaining="${remaining#*"$matched_text"}"
+          done
+          if (( ${#identity_pairs[@]} != 1 )); then
+            echo "Expected exactly one adjacent app/platform build ID pair; found ${#identity_pairs[@]}." >&2
+            exit 1
+          fi
+
+          read -r app_build_id platform_build_id <<< "${identity_pairs[0]}"
+          if [[ "$app_build_id" != "$EXPECTED_BUILD_ID" ]]; then
+            echo "App build ID mismatch: expected $EXPECTED_BUILD_ID, got $app_build_id." >&2
+            exit 1
+          fi
+          if [[ "$platform_build_id" != "$EXPECTED_BUILD_ID" ]]; then
+            echo "Platform build ID mismatch: expected $EXPECTED_BUILD_ID, got $platform_build_id." >&2
+            exit 1
+          fi
+
+          application_ini="$(dirname "$BROWSER_PATH")/application.ini"
+          if [[ -f "$application_ini" ]]; then
+            diagnostic_build_id="$(awk -F= '
+              /^\[App\]$/ { in_app = 1; next }
+              /^\[/ { in_app = 0 }
+              in_app && $1 == "BuildID" { print $2; exit }
+            ' "$application_ini")"
+            echo "Diagnostic application.ini BuildID: ${diagnostic_build_id:-<missing>}"
+          else
+            echo "Diagnostic application.ini BuildID: <file missing>"
+          fi
+          echo "Stage 1 native app and platform build IDs both match $EXPECTED_BUILD_ID."
+
+      - name: Generate profile
+        shell: bash
+        run: |
+          set -euo pipefail
           export MOZ_FETCHES_DIR=/tmp
           export JARLOG_FILE=en-US.log
           export LLVM_PROFDATA=/tmp/clang/bin/llvm-profdata
@@ -161,119 +218,10 @@ jobs:
           # Start Xvfb
           Xvfb :99 -screen 0 1024x768x24 &
           XVFB_PID=$!
+          trap 'kill "$XVFB_PID" 2>/dev/null || true' EXIT
           sleep 3
 
-          # Find browser binary (look for actual executable files, not directories)
-          echo "Looking for browser binary in obj-firefox/dist/firefox/..."
-          ls -la obj-firefox/dist/firefox/ || echo "Directory doesn't exist or is empty"
-
-          BROWSER=""
-          for binary_name in floorp firefox firefox-bin; do
-            if [[ -f "obj-firefox/dist/firefox/$binary_name" ]]; then
-              BROWSER="obj-firefox/dist/firefox/$binary_name"
-              break
-            fi
-          done
-
-          if [[ -z "$BROWSER" ]]; then
-            echo "No browser binary found. Available files:"
-            find obj-firefox/dist/firefox -type f -executable 2>/dev/null || echo "No executable files found"
-            find obj-firefox/dist/firefox -name "*" -type f | head -10
-            kill $XVFB_PID
-            exit 1
-          fi
-
-          echo "Found browser binary: $BROWSER"
-
-          # Check architecture and handle accordingly
-          ARCH=$(file "$BROWSER" | grep -o "ARM aarch64\|x86-64\|x86_64")
-          echo "Browser binary architecture: $ARCH"
-
-          if [[ "${{ inputs.target-arch }}" == "aarch64" && "$ARCH" == *"ARM aarch64"* ]]; then
-            echo "Running ARM64 binary with QEMU user-mode emulation"
-
-            # Ensure QEMU is available
-            QEMU_PATH=""
-            if [[ -f "/usr/bin/qemu-aarch64-static" ]]; then
-              QEMU_PATH="/usr/bin/qemu-aarch64-static"
-            elif [[ -f "/usr/local/bin/qemu-aarch64-static" ]]; then
-              QEMU_PATH="/usr/local/bin/qemu-aarch64-static"
-            else
-              echo "ERROR: qemu-aarch64-static not found in standard locations"
-              kill $XVFB_PID
-              exit 1
-            fi
-
-            echo "Found QEMU at: $QEMU_PATH"
-
-            # Ensure QEMU static is properly registered with binfmt_misc
-            if [[ ! -f /proc/sys/fs/binfmt_misc/qemu-aarch64 ]]; then
-              echo "Registering QEMU ARM64 handler with binfmt_misc"
-              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-              sleep 3
-            fi
-
-            # Make sure the binary is executable
-            chmod +x "$BROWSER"
-
-            # Store the actual browser path
-            ACTUAL_BROWSER="$BROWSER"
-
-            # Create a wrapper script with QEMU_LD_PREFIX  
-            echo "Creating QEMU wrapper script with library path..."
-            cat > browser-wrapper.sh << 'WRAPPER_SCRIPT_END'
-          #!/bin/bash
-          export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu
-          export LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib
-          BROWSER_BIN="$1"
-          shift
-          exec "$BROWSER_BIN" "$@"
-          WRAPPER_SCRIPT_END
-
-            chmod +x browser-wrapper.sh
-            
-            # Test if binfmt handles ARM64 execution with the wrapper
-            echo "Testing ARM64 execution with QEMU and library prefix..."
-            if timeout 15s bash browser-wrapper.sh "$ACTUAL_BROWSER" --version 2>&1; then
-              echo "✓ ARM64 execution test passed"
-            else
-              echo "⚠ Direct execution test failed, but continuing with wrapper"
-            fi
-
-            # Update BROWSER to use wrapper with actual browser as argument
-            BROWSER="bash $GITHUB_WORKSPACE/browser-wrapper.sh $ACTUAL_BROWSER"
-            echo "Final browser command: $BROWSER"
-          else
-            chmod +x "$BROWSER"
-          fi
-
-          # Verify browser is executable
-          echo "Testing browser execution..."
-          if timeout 30s "$BROWSER" --version 2>&1; then
-            echo "✓ Browser execution test passed"
-          else
-            EXIT_CODE=$?
-            echo "✗ Browser execution test failed with exit code: $EXIT_CODE"
-            if [[ "${{ inputs.target-arch }}" == "aarch64" ]]; then
-              echo "Debugging QEMU/binfmt setup:"
-              which qemu-aarch64-static || echo "  qemu-aarch64-static not in PATH"
-              ls -la /proc/sys/fs/binfmt_misc/qemu-aarch64 2>/dev/null || echo "  QEMU ARM64 binfmt not registered"
-              file "$BROWSER"
-              echo "  This may still work for profile generation..."
-            else
-              kill $XVFB_PID
-              exit 1
-            fi
-          fi
-
-          echo "Final browser path: $BROWSER"
-
-          # Generate profile
-          echo "Starting profile generation..."
-          ./mach python build/pgo/profileserver.py --binary "$BROWSER"
-
-          # Cleanup
-          kill $XVFB_PID
+          ./mach python build/pgo/profileserver.py --binary "$BROWSER_PATH"
 
       - name: Upload profile data
         uses: actions/upload-artifact@v4
@@ -283,3 +231,5 @@ jobs:
             merged.profdata
             en-US.log
           retention-days: 7
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/generate-pgo-profile-windows.yml
+++ b/.github/workflows/generate-pgo-profile-windows.yml
@@ -6,6 +6,10 @@ name: Generate PGO Profile (Windows)
 on:
   workflow_call:
     inputs:
+      MOZ_BUILD_DATE:
+        description: 'Expected Stage 1 build ID (14 UTC digits)'
+        required: true
+        type: string
       browser-artifact-name:
         description: 'Browser artifact to download'
         required: true
@@ -30,6 +34,10 @@ on:
         required: false
         type: string
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   generate-profdata-and-jarlog:
     name: Generate PGO Profile Data (${{ inputs.target-arch }})
@@ -37,6 +45,7 @@ jobs:
     env:
       ARTIFACT_PATH: ${{ inputs.artifact-path }}
       TARGET_ARCH: ${{ inputs.target-arch }}
+      EXPECTED_BUILD_ID: ${{ inputs.MOZ_BUILD_DATE }}
       UPLOAD_ARTIFACT_NAME: >-
         ${{ inputs.upload-artifact-name ||
         format('{0}-profile-generate-output', inputs.browser-artifact-name) }}
@@ -64,6 +73,102 @@ jobs:
             Get-ChildItem -Path $artifactPath -Recurse -Depth 1 | ForEach-Object { Write-Host $_.FullName }
           } else {
             Write-Error "No zip file found in $artifactPath"
+          }
+
+      - name: Verify Stage 1 native build identity
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ($env:EXPECTED_BUILD_ID -notmatch '^\d{14}$') {
+            throw "Expected build ID must contain exactly 14 digits."
+          }
+
+          $browserDirectory = Join-Path $env:ARTIFACT_PATH 'floorp'
+          $browserPath = Join-Path $browserDirectory 'floorp.exe'
+          if (-not (Test-Path -LiteralPath $browserPath -PathType Leaf)) {
+            throw "Stage 1 browser executable not found at $browserPath"
+          }
+
+          $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+          $startInfo.FileName = $browserPath
+          $startInfo.Arguments = '--full-version'
+          $startInfo.WorkingDirectory = $browserDirectory
+          $startInfo.UseShellExecute = $false
+          $startInfo.RedirectStandardOutput = $true
+          $startInfo.RedirectStandardError = $true
+          $startInfo.CreateNoWindow = $true
+          [void]$startInfo.Environment.Remove('XUL_APP_FILE')
+
+          $process = [System.Diagnostics.Process]::new()
+          $process.StartInfo = $startInfo
+          try {
+            if (-not $process.Start()) {
+              throw "Failed to start $browserPath"
+            }
+
+            $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+            $stderrTask = $process.StandardError.ReadToEndAsync()
+            $process.WaitForExit()
+            $stdout = $stdoutTask.GetAwaiter().GetResult()
+            $stderr = $stderrTask.GetAwaiter().GetResult()
+            $exitCode = $process.ExitCode
+          } finally {
+            $process.Dispose()
+          }
+
+          Write-Host "floorp.exe --full-version stdout: $stdout"
+          if ($stderr) {
+            Write-Host "floorp.exe --full-version stderr: $stderr"
+          }
+          if ($exitCode -ne 0) {
+            throw "floorp.exe --full-version exited with code $exitCode"
+          }
+
+          $allBuildIds = [regex]::Matches($stdout, '(?<!\d)\d{14}(?!\d)')
+          if ($allBuildIds.Count -ne 2) {
+            throw "Expected exactly two 14-digit build IDs in --full-version output; found $($allBuildIds.Count)."
+          }
+
+          $identityPattern = '(?<!\d)(?<application>\d{14})\s+(?<platform>\d{14})(?!\d)'
+          $identityMatches = [regex]::Matches($stdout, $identityPattern)
+          if ($identityMatches.Count -ne 1) {
+            throw "Expected one adjacent application/platform build ID pair in --full-version output; found $($identityMatches.Count)."
+          }
+
+          $applicationBuildId = $identityMatches[0].Groups['application'].Value
+          $platformBuildId = $identityMatches[0].Groups['platform'].Value
+          if ($applicationBuildId -ne $env:EXPECTED_BUILD_ID -or
+              $platformBuildId -ne $env:EXPECTED_BUILD_ID) {
+            throw "Native build ID mismatch: expected $env:EXPECTED_BUILD_ID, application=$applicationBuildId, platform=$platformBuildId"
+          }
+          Write-Host "Verified native Stage 1 build IDs: $applicationBuildId $platformBuildId"
+
+          # application.ini is useful context, but the native process output is
+          # the authoritative identity check above.
+          $applicationIniPath = Join-Path $browserDirectory 'application.ini'
+          if (Test-Path -LiteralPath $applicationIniPath -PathType Leaf) {
+            try {
+              $iniBuildId = $null
+              foreach ($line in Get-Content -LiteralPath $applicationIniPath) {
+                if ($line -match '^BuildID=(\d{14})$') {
+                  $iniBuildId = $Matches[1]
+                  break
+                }
+              }
+              if ($iniBuildId) {
+                Write-Host "Diagnostic application.ini BuildID: $iniBuildId"
+                if ($iniBuildId -ne $env:EXPECTED_BUILD_ID) {
+                  Write-Warning "Diagnostic application.ini BuildID differs from the expected native identity."
+                }
+              } else {
+                Write-Warning "Diagnostic application.ini has no 14-digit BuildID."
+              }
+            } catch {
+              Write-Warning "Could not read diagnostic application.ini: $($_.Exception.Message)"
+            }
+          } else {
+            Write-Warning "Diagnostic application.ini not found at $applicationIniPath"
           }
 
       - name: Setup Mozilla Build
@@ -107,3 +212,5 @@ jobs:
             merged.profdata
             en-US.log
           retention-days: 7
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/mac_integration.yml
+++ b/.github/workflows/mac_integration.yml
@@ -18,15 +18,38 @@ on:
         type: boolean
         default: false
       MOZ_BUILD_DATE:
+        description: "Resolved 14-digit build ID"
         type: string
-        default: ""
+        required: true
       debug:
         type: boolean
         default: false
+    outputs:
+      artifact-name:
+        description: "Final universal macOS artifact name"
+        value: ${{ jobs.Integration.outputs.artifact-name }}
+      artifact-id:
+        description: "Final universal macOS artifact ID"
+        value: ${{ jobs.Integration.outputs.artifact-id }}
+      artifact-digest:
+        description: "Final universal macOS artifact digest"
+        value: ${{ jobs.Integration.outputs.artifact-digest }}
+      expected-build-id:
+        description: "Expected build ID embedded in the artifact"
+        value: ${{ jobs.Integration.outputs.expected-build-id }}
+
+permissions:
+  actions: read
+  contents: read
 
 jobs:
   Integration:
     runs-on: macos-26
+    outputs:
+      artifact-name: floorp-mac-universal-moz-artifact
+      artifact-id: ${{ steps.upload-primary.outputs.artifact-id }}
+      artifact-digest: ${{ steps.upload-primary.outputs.artifact-digest }}
+      expected-build-id: ${{ inputs.MOZ_BUILD_DATE }}
     steps:
       - name: Init
         run: |
@@ -71,13 +94,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.aarch64_artifact_name }}
-          path: ./
+          path: ./downloaded-artifacts/aarch64
 
       - name: download x86_64 build artifact 📥
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.x86_64_artifact_name }}
-          path: ./
+          path: ./downloaded-artifacts/x86_64
 
       - name: Download macOS SDK
         uses: actions/download-artifact@v4
@@ -93,12 +116,20 @@ jobs:
 
       - name: Extract 📦
         run: |
+          set -euo pipefail
+          X86_64_ARCHIVE=./downloaded-artifacts/x86_64/floorp-mac-x86_64-moz-artifact.tar.gz
+          AARCH64_ARCHIVE=./downloaded-artifacts/aarch64/floorp-mac-aarch64-moz-artifact.tar.gz
+
+          if [[ ! -f "$X86_64_ARCHIVE" || ! -f "$AARCH64_ARCHIVE" ]]; then
+            echo "Missing one or both architecture package archives" >&2
+            find ./downloaded-artifacts -maxdepth 3 -type f -print >&2
+            exit 1
+          fi
+
           mkdir -p ./obj-x86_64-apple-darwin/dist
-          tar -xf ./floorp-mac-x86_64-moz-artifact.tar.gz -C ./obj-x86_64-apple-darwin/dist
-          rm ./floorp-mac-x86_64-moz-artifact.tar.gz
+          tar -xf "$X86_64_ARCHIVE" -C ./obj-x86_64-apple-darwin/dist
           mkdir -p ./obj-aarch64-apple-darwin/dist
-          tar -xf ./floorp-mac-aarch64-moz-artifact.tar.gz -C ./obj-aarch64-apple-darwin/dist
-          rm ./floorp-mac-aarch64-moz-artifact.tar.gz
+          tar -xf "$AARCH64_ARCHIVE" -C ./obj-aarch64-apple-darwin/dist
 
       - name: Check Branding Type
         shell: bash
@@ -131,15 +162,11 @@ jobs:
       - name: setup environment 🌲
         continue-on-error: true
         env:
-          GHA_BUILD_MACHINE: ${{ matrix.runs-on }}
           SDKROOT: ${{ env.RUNNER_USERDIR }}/macos-sdk
           MACOS_SDK_DIR: ${{ env.RUNNER_USERDIR }}/macos-sdk
           MOZ_SDK_DIR: ${{ env.RUNNER_USERDIR }}/macos-sdk
+          MOZ_BUILD_DATE: ${{ inputs.MOZ_BUILD_DATE }}
         run: |
-          if [[ -n ${{ inputs.MOZ_BUILD_DATE }} ]]; then
-            export MOZ_BUILD_DATE=${{ inputs.MOZ_BUILD_DATE }}
-          fi
-
           echo "ac_add_options --disable-bootstrap" >> mozconfig
 
           # Add macOS SDK path
@@ -236,28 +263,19 @@ jobs:
 
       - name: Integration 🗃
         env:
-          GHA_BUILD_MACHINE: ${{ matrix.runs-on }}
           SDKROOT: ${{ env.RUNNER_USERDIR }}/macos-sdk
           MACOS_SDK_DIR: ${{ env.RUNNER_USERDIR }}/macos-sdk
           MOZ_SDK_DIR: ${{ env.RUNNER_USERDIR }}/macos-sdk
+          MOZ_BUILD_DATE: ${{ inputs.MOZ_BUILD_DATE }}
         run: |
-          if [[ -n ${{ inputs.MOZ_BUILD_DATE }} ]]; then
-            export MOZ_BUILD_DATE=${{ inputs.MOZ_BUILD_DATE }}
-          fi
-
           ./mach python "./toolkit/mozapps/installer/unify.py" ./obj-x86_64-apple-darwin/dist/floorp/*.app ./obj-aarch64-apple-darwin/dist/floorp/*.app
-
       - name: Create DMG 📦
         env:
-          GHA_BUILD_MACHINE: ${{ matrix.runs-on }}
           SDKROOT: ${{ env.RUNNER_USERDIR }}/macos-sdk
           MACOS_SDK_DIR: ${{ env.RUNNER_USERDIR }}/macos-sdk
           MOZ_SDK_DIR: ${{ env.RUNNER_USERDIR }}/macos-sdk
+          MOZ_BUILD_DATE: ${{ inputs.MOZ_BUILD_DATE }}
         run: |
-          if [[ -n ${{ inputs.MOZ_BUILD_DATE }} ]]; then
-            export MOZ_BUILD_DATE=${{ inputs.MOZ_BUILD_DATE }}
-          fi
-
           ./mach python -m mozbuild.action.make_dmg ./obj-x86_64-apple-darwin/dist/floorp floorp-macOS-universal-moz-artifact.dmg
 
           cp ./obj-x86_64-apple-darwin/dist/floorp*update_framework_artifacts.zip ./floorp-macOS.update_framework_artifacts.zip
@@ -266,28 +284,56 @@ jobs:
           APP_DIR=$(find ./obj-x86_64-apple-darwin/dist/floorp -maxdepth 1 -name "*.app" -type d | head -n 1)
           cp "${APP_DIR}/Contents/Resources/application.ini" ./floorp-application.ini
 
-      # Publish Start
-      - name: Remove old uploaded artifacts
-        uses: geekyeggo/delete-artifact@v5.1.0
-        with:
-          name: |
-            floorp-mac-x86_64-package
-            floorp-mac-aarch64-package
+      - name: Stage consolidated universal artifact
+        env:
+          EXPECTED_BUILD_ID: ${{ inputs.MOZ_BUILD_DATE }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$EXPECTED_BUILD_ID" =~ ^[0-9]{14}$ ]]; then
+            echo "Expected build ID must be exactly 14 digits: $EXPECTED_BUILD_ID" >&2
+            exit 1
+          fi
+
+          ACTUAL_BUILD_ID=$(awk -F= '$1 == "BuildID" { print $2; exit }' ./floorp-application.ini | tr -d '\r')
+          if [[ "$ACTUAL_BUILD_ID" != "$EXPECTED_BUILD_ID" ]]; then
+            echo "Universal application.ini BuildID $ACTUAL_BUILD_ID does not match $EXPECTED_BUILD_ID" >&2
+            exit 1
+          fi
+
+          STAGE_DIR=./artifact-stage/floorp-mac-universal-moz-artifact
+          rm -rf "$STAGE_DIR"
+          mkdir -p "$STAGE_DIR/dist-host"
+
+          cp ./floorp-macOS-universal-moz-artifact.dmg "$STAGE_DIR/"
+          cp ./floorp-macOS.update_framework_artifacts.zip "$STAGE_DIR/"
+          cp -a ./obj-x86_64-apple-darwin/dist/host/. "$STAGE_DIR/dist-host/"
+          cp ./floorp-application.ini "$STAGE_DIR/floorp-application.ini"
+
+          test -s "$STAGE_DIR/floorp-macOS-universal-moz-artifact.dmg"
+          test -s "$STAGE_DIR/floorp-macOS.update_framework_artifacts.zip"
+          test -s "$STAGE_DIR/floorp-application.ini"
+          HOST_ENTRY=$(find "$STAGE_DIR/dist-host" -type f -print | sed -n '1p')
+          if [[ -z "$HOST_ENTRY" ]]; then
+            echo "The consolidated artifact has an empty dist-host directory" >&2
+            exit 1
+          fi
 
       - name: Publish Package Mozilla Artifact 🎁
+        id: upload-primary
         uses: actions/upload-artifact@v4
         with:
           name: floorp-mac-universal-moz-artifact
-          if-no-files-found: ignore
-          path: |
-            ./floorp-macOS-universal-moz-artifact.dmg
-            ./floorp-macOS.update_framework_artifacts.zip
+          path: ./artifact-stage/floorp-mac-universal-moz-artifact/
+          if-no-files-found: error
+          overwrite: true
 
       - name: Publish dist/host for MAR
         uses: actions/upload-artifact@v4
         with:
           name: macOS-universal-dist-host
           path: obj-x86_64-apple-darwin/dist/host/
+          if-no-files-found: error
           overwrite: true
 
       - name: Publish floorp-application.ini for MAR
@@ -295,7 +341,7 @@ jobs:
         with:
           name: macOS-universal-application-ini
           path: ./floorp-application.ini
+          if-no-files-found: error
           overwrite: true
-      # Publish End
 
 

--- a/.github/workflows/mac_pgo.yml
+++ b/.github/workflows/mac_pgo.yml
@@ -3,15 +3,33 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 on:
-    workflow_call:
+  workflow_call:
+    inputs:
+      MOZ_BUILD_DATE:
+        description: "Resolved 14-digit build ID"
+        type: string
+        required: true
+
+permissions:
+  actions: read
+  contents: read
 
 jobs:
   macOS-Universal-gen-profdata-and-jarlog:
     runs-on: ${{ matrix.runs-on }}
+    env:
+      ARCH_TYPE: ${{ matrix.arch }}
+      MOZ_BUILD_DATE: ${{ inputs.MOZ_BUILD_DATE }}
     strategy:
+      fail-fast: false
       matrix:
-        runs-on: [macos-15-intel, macos-14]
-        # macos-15-intel is x86_64 and macos-14 is arm64
+        include:
+          - runs-on: macos-15-intel
+            arch: x86_64
+            runner-arch: x86_64
+          - runs-on: macos-14
+            arch: aarch64
+            runner-arch: arm64
 
     steps:
       - name: Init
@@ -25,19 +43,6 @@ jobs:
         name: Clone 🧬
         with:
           submodules: 'true'
-
-      - name: Check Arch type
-        shell: bash
-        run: |
-          if [[ $GHA_BUILD_MACHINE != 'macos-15-intel' ]]; then
-            export ARCH_TYPE=`echo "aarch64"`
-            echo "ARCH_TYPE=$ARCH_TYPE" >> $GITHUB_ENV
-          else
-            export ARCH_TYPE=`echo "x86_64"`
-            echo "ARCH_TYPE=$ARCH_TYPE" >> $GITHUB_ENV
-          fi
-        env:
-          GHA_BUILD_MACHINE: ${{ matrix.runs-on }}
 
       - uses: actions/download-artifact@v4
         id: download-artifacts-mac-enable-profgen
@@ -131,6 +136,7 @@ jobs:
 
       - name: Extract artifact 📂
         run: |
+          set -euo pipefail
           cd ~/downloads/artifacts
           echo "Contents of download path:"
           ls -la
@@ -138,6 +144,57 @@ jobs:
           tar xzf floorp-mac-${ARCH_TYPE}-moz-artifact.tar.gz -C ${{ github.workspace }}
           echo "Extraction complete. Checking workspace:"
           ls -la ${{ github.workspace }}/obj-${ARCH_TYPE}-apple-darwin/ || echo "Directory not found"
+
+      - name: Verify Stage 1 runtime build identity
+        shell: bash
+        env:
+          EXPECTED_RUNNER_ARCH: ${{ matrix.runner-arch }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$MOZ_BUILD_DATE" =~ ^[0-9]{14}$ ]]; then
+            echo "Expected build ID must be exactly 14 digits: $MOZ_BUILD_DATE" >&2
+            exit 1
+          fi
+
+          RUNNER_ARCH=$(uname -m)
+          if [[ "$RUNNER_ARCH" != "$EXPECTED_RUNNER_ARCH" ]]; then
+            echo "Runner architecture $RUNNER_ARCH does not match $EXPECTED_RUNNER_ARCH for $ARCH_TYPE" >&2
+            exit 1
+          fi
+
+          APP_BINARY=$(find \
+            "./obj-${ARCH_TYPE}-apple-darwin/dist/floorp" \
+            -type f -path "*.app/Contents/MacOS/floorp" -print | sed -n '1p')
+          if [[ -z "$APP_BINARY" || ! -x "$APP_BINARY" ]]; then
+            echo "Unable to locate an executable Stage 1 Floorp app for $ARCH_TYPE" >&2
+            exit 1
+          fi
+
+          unset XUL_APP_FILE
+          echo "Running native identity check: $APP_BINARY --full-version"
+          FULL_VERSION_OUTPUT=$("$APP_BINARY" --full-version 2>&1)
+          printf '%s\n' "$FULL_VERSION_OUTPUT"
+
+          BUILD_IDS=$(printf '%s\n' "$FULL_VERSION_OUTPUT" | grep -Eo '[0-9]{14}' || true)
+          BUILD_ID_COUNT=$(printf '%s\n' "$BUILD_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+          FIRST_BUILD_ID=$(printf '%s\n' "$BUILD_IDS" | sed -n '1p')
+          SECOND_BUILD_ID=$(printf '%s\n' "$BUILD_IDS" | sed -n '2p')
+
+          if [[ "$BUILD_ID_COUNT" != "2" ]]; then
+            echo "Expected exactly two 14-digit IDs from --full-version, found $BUILD_ID_COUNT" >&2
+            exit 1
+          fi
+          if [[ "$FIRST_BUILD_ID" != "$MOZ_BUILD_DATE" || "$SECOND_BUILD_ID" != "$MOZ_BUILD_DATE" ]]; then
+            echo "Stage 1 IDs do not both match expected build ID $MOZ_BUILD_DATE" >&2
+            exit 1
+          fi
+          if ! printf '%s\n' "$FULL_VERSION_OUTPUT" | grep -Eq "(^|[^0-9])${MOZ_BUILD_DATE}[[:space:]]+${MOZ_BUILD_DATE}([^0-9]|$)"; then
+            echo "The two expected build IDs are not adjacent in --full-version output" >&2
+            exit 1
+          fi
+
+          echo "STAGE1_APP_BINARY=$APP_BINARY" >> "$GITHUB_ENV"
 
 ## ./mach python python/mozbuild/mozbuild/action/install.py $MOZ_FETCHES_DIR/target.dmg $MOZ_FETCHES_DIR
       - name: Generate Profdata 📊
@@ -160,7 +217,7 @@ jobs:
           $LLVM_PROFDATA --version || echo "llvm-profdata version check failed"
           
           export JARLOG_FILE="en-US.log"
-          ./mach python build/pgo/profileserver.py --binary ./obj-${ARCH_TYPE}-apple-darwin/dist/floorp/Floorp.app/Contents/MacOS/floorp
+          ./mach python build/pgo/profileserver.py --binary "$STAGE1_APP_BINARY"
 
       - name: Publish 🎁
         uses: actions/upload-artifact@v4
@@ -169,3 +226,5 @@ jobs:
           path: |
             merged.profdata
             en-US.log
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/resolve-build-context.yml
+++ b/.github/workflows/resolve-build-context.yml
@@ -1,0 +1,77 @@
+---
+# SPDX-License-Identifier: MPL-2.0
+
+name: Resolve Runtime Build Context
+
+permissions:
+  actions: read
+  contents: read
+
+'on':
+  workflow_call:
+    inputs:
+      resolved_moz_build_date:
+        description: Trusted build ID propagated by a parent workflow
+        type: string
+        required: false
+        default: ''
+      requested_moz_build_date:
+        description: Optional assertion for the resolved build ID
+        type: string
+        required: false
+        default: ''
+      require_run_metadata:
+        description: Require validated metadata from the current Actions run
+        type: boolean
+        required: false
+        default: false
+    outputs:
+      expected-build-id:
+        description: UTC build ID derived from the Actions run creation time
+        value: ${{ jobs.resolve.outputs['expected-build-id'] }}
+      repository:
+        description: Validated repository full name
+        value: ${{ jobs.resolve.outputs.repository }}
+      head-sha:
+        description: Validated workflow head SHA
+        value: ${{ jobs.resolve.outputs['head-sha'] }}
+      workflow-run-id:
+        description: Validated Actions workflow run ID
+        value: ${{ jobs.resolve.outputs['workflow-run-id'] }}
+      run-created-at:
+        description: Canonical Actions run creation time when REST was required
+        value: ${{ jobs.resolve.outputs['run-created-at'] }}
+      run-attempt:
+        description: Validated Actions run attempt observation
+        value: ${{ jobs.resolve.outputs['run-attempt'] }}
+
+jobs:
+  resolve:
+    name: Resolve build context
+    runs-on: ubuntu-latest
+    outputs:
+      expected-build-id: ${{ steps.context.outputs['expected-build-id'] }}
+      repository: ${{ steps.context.outputs.repository }}
+      head-sha: ${{ steps.context.outputs['head-sha'] }}
+      workflow-run-id: ${{ steps.context.outputs['workflow-run-id'] }}
+      run-created-at: ${{ steps.context.outputs['run-created-at'] }}
+      run-attempt: ${{ steps.context.outputs['run-attempt'] }}
+    steps:
+      - name: Checkout build-context resolver
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/workflows/scripts/runtime_build_context.py
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve and validate build context
+        id: context
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REQUESTED_MOZ_BUILD_DATE: ${{ inputs.requested_moz_build_date }}
+          REQUIRE_RUN_METADATA: ${{ toJSON(inputs.require_run_metadata) }}
+          RESOLVED_MOZ_BUILD_DATE: ${{ inputs.resolved_moz_build_date }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/workflows/scripts/runtime_build_context.py

--- a/.github/workflows/scripts/build-and-package.sh
+++ b/.github/workflows/scripts/build-and-package.sh
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MPL-2.0
-set -e
+set -eo pipefail
 
 # Arguments:
 #   $1: platform (linux|mac|windows)
 #   $2: arch (x86_64|aarch64)
-#   $3: MOZ_BUILD_DATE (optional)
+#   $3: MOZ_BUILD_DATE (required, 14 decimal digits)
+#   $4: PGO mode (optional)
 
-PLATFORM="$1"
-ARCH="$2"
-MOZ_BUILD_DATE="$3"
-PGO_MODE="$4"
+PLATFORM="${1:-}"
+ARCH="${2:-}"
+MOZ_BUILD_DATE="${3:-}"
+PGO_MODE="${4:-}"
 
-if [[ -n "$MOZ_BUILD_DATE" ]]; then
-  export MOZ_BUILD_DATE="$MOZ_BUILD_DATE"
+if [[ ! "$MOZ_BUILD_DATE" =~ ^[0-9]{14}$ ]]; then
+  echo "MOZ_BUILD_DATE must be exactly 14 decimal digits (YYYYMMDDhhmmss)." >&2
+  exit 1
 fi
+export MOZ_BUILD_DATE
 
 export MOZ_NUM_JOBS=$(( $(nproc) * 3 / 4 ))
 if [[ "$PLATFORM" == "linux" ]]; then
@@ -51,52 +54,157 @@ else
 fi
 rm -rf ~/.cargo
 
-# Artifact packaging
-mkdir -p ~/output
+# Artifact packaging. The primary artifact is a consolidated bundle whose
+# package remains at the artifact root for compatibility with existing users.
+case "${PLATFORM}/${ARCH}" in
+  windows/x86_64)
+    OBJDIR="obj-x86_64-pc-windows-msvc"
+    PACKAGE_EXTENSION="zip"
+    ;;
+  linux/x86_64)
+    OBJDIR="obj-x86_64-pc-linux-gnu"
+    PACKAGE_EXTENSION="tar.xz"
+    ;;
+  linux/aarch64)
+    OBJDIR="obj-aarch64-unknown-linux-gnu"
+    PACKAGE_EXTENSION="tar.xz"
+    ;;
+  mac/x86_64 | mac/aarch64)
+    OBJDIR="obj-${ARCH}-apple-darwin"
+    PACKAGE_EXTENSION="tar.gz"
+    ;;
+  *)
+    echo "Unsupported platform/architecture combination: ${PLATFORM}/${ARCH}" >&2
+    exit 1
+    ;;
+esac
 
-ARTIFACT_NAME="floorp-${PLATFORM}-${ARCH}-moz-artifact"
-if [[ "$PLATFORM" == "windows" ]]; then
-  mv obj-x86_64-pc-windows-msvc/dist/floorp-*win64.zip ~/output/${ARTIFACT_NAME}.zip
-  cp ./obj-x86_64-pc-windows-msvc/dist/bin/application.ini ./floorp-application.ini || true
-elif [[ "$PLATFORM" == "linux" ]]; then
-  if [[ "$ARCH" == "aarch64" ]]; then
-    mv obj-aarch64-unknown-linux-gnu/dist/floorp-*.tar.xz ~/output/${ARTIFACT_NAME}.tar.xz
-    cp ./obj-aarch64-unknown-linux-gnu/dist/bin/application.ini ./floorp-application.ini || true
-  else
-    mv obj-x86_64-pc-linux-gnu/dist/floorp-*.tar.xz ~/output/${ARTIFACT_NAME}.tar.xz
-    cp obj-x86_64-pc-linux-gnu/dist/bin/application.ini ./floorp-application.ini || true
+# Exercise the built binary only when it is native to the Linux runner. Cross
+# targets are verified later on their native downstream runners.
+if [[ "$PLATFORM" == "linux" && "$ARCH" == "x86_64" && "$PGO_MODE" != "generate" ]]; then
+  FULL_VERSION_BINARY="${OBJDIR}/dist/bin/floorp"
+  if [[ ! -x "$FULL_VERSION_BINARY" ]]; then
+    echo "Native --full-version probe is not executable: ${FULL_VERSION_BINARY}" >&2
+    exit 1
   fi
-elif [[ "$PLATFORM" == "mac" ]]; then
-  if [[ "$PGO_MODE" == "generate" ]]; then
-    tar -czf "floorp-${ARCH}-apple-darwin-with-pgo.tar.gz" "./obj-${ARCH}-apple-darwin/"
-    mv "floorp-${ARCH}-apple-darwin-with-pgo.tar.gz" ~/output/"${ARTIFACT_NAME}.tar.gz"
+
+  unset XUL_APP_FILE
+  if FULL_VERSION_OUTPUT="$(timeout 30s "$FULL_VERSION_BINARY" --full-version 2>&1)"; then
+    :
   else
-    tar -czf "floorp-${ARCH}-apple-darwin-dist.tar.gz" -C "./obj-${ARCH}-apple-darwin/dist" .
-    mv "floorp-${ARCH}-apple-darwin-dist.tar.gz" ~/output/"${ARTIFACT_NAME}.tar.gz"
+    FULL_VERSION_STATUS=$?
+    echo "Native --full-version probe failed with exit code ${FULL_VERSION_STATUS}." >&2
+    printf '%s\n' "$FULL_VERSION_OUTPUT" >&2
+    exit "$FULL_VERSION_STATUS"
   fi
+  FULL_VERSION_PAIRS=()
+  while IFS= read -r line; do
+    read -r -a tokens <<< "$line"
+    for ((i = 0; i + 1 < ${#tokens[@]}; i++)); do
+      if [[ "${tokens[i]}" =~ ^[0-9]{14}$ && "${tokens[i + 1]}" =~ ^[0-9]{14}$ ]]; then
+        FULL_VERSION_PAIRS+=("${tokens[i]} ${tokens[i + 1]}")
+      fi
+    done
+  done <<< "$FULL_VERSION_OUTPUT"
+
+  if (( ${#FULL_VERSION_PAIRS[@]} != 1 )); then
+    echo "Expected exactly one adjacent application/platform BuildID pair from --full-version, found ${#FULL_VERSION_PAIRS[@]}." >&2
+    printf '%s\n' "$FULL_VERSION_OUTPUT" >&2
+    exit 1
+  fi
+
+  read -r APPLICATION_FULL_VERSION_ID PLATFORM_FULL_VERSION_ID <<< "${FULL_VERSION_PAIRS[0]}"
+  if [[ "$APPLICATION_FULL_VERSION_ID" != "$MOZ_BUILD_DATE" || "$PLATFORM_FULL_VERSION_ID" != "$MOZ_BUILD_DATE" ]]; then
+    echo "Native --full-version BuildIDs (${APPLICATION_FULL_VERSION_ID}, ${PLATFORM_FULL_VERSION_ID}) do not both match ${MOZ_BUILD_DATE}." >&2
+    exit 1
+  fi
+  echo "Native --full-version BuildIDs match expected build ID: ${MOZ_BUILD_DATE}"
 fi
 
-# Stage dist-host directory with a stable root for downstream workflows.
-DIST_HOST_DEST="$HOME/output/${PLATFORM}-${ARCH}-dist-host"
-rm -rf "$DIST_HOST_DEST"
+: "${HOME:?HOME must be set}"
+ARTIFACT_NAME="floorp-${PLATFORM}-${ARCH}-moz-artifact"
+OUTPUT_ROOT="${HOME}/output"
+BUNDLE_DIR="${OUTPUT_ROOT}/${ARTIFACT_NAME}-bundle"
+PACKAGE_DEST="${BUNDLE_DIR}/${ARTIFACT_NAME}.${PACKAGE_EXTENSION}"
+DIST_HOST_SRC="${OBJDIR}/dist/host"
+DIST_HOST_DEST="${BUNDLE_DIR}/dist-host"
+
+# Keep cleanup narrowly scoped to this build's staging directory.
+case "$BUNDLE_DIR" in
+  "${OUTPUT_ROOT}/"floorp-*-moz-artifact-bundle) ;;
+  *)
+    echo "Refusing to clean unexpected bundle path: ${BUNDLE_DIR}" >&2
+    exit 1
+    ;;
+esac
+rm -rf -- "$BUNDLE_DIR"
 mkdir -p "$DIST_HOST_DEST"
 
+shopt -s nullglob
 if [[ "$PLATFORM" == "windows" ]]; then
-  DIST_HOST_SRC="obj-x86_64-pc-windows-msvc/dist/host"
-elif [[ "$PLATFORM" == "linux" ]]; then
-  if [[ "$ARCH" == "aarch64" ]]; then
-    DIST_HOST_SRC="obj-aarch64-unknown-linux-gnu/dist/host"
-  else
-    DIST_HOST_SRC="obj-x86_64-pc-linux-gnu/dist/host"
+  PACKAGE_MATCHES=("${OBJDIR}"/dist/floorp-*win64.zip)
+  if (( ${#PACKAGE_MATCHES[@]} != 1 )); then
+    echo "Expected exactly one Windows package, found ${#PACKAGE_MATCHES[@]}." >&2
+    printf '  %s\n' "${PACKAGE_MATCHES[@]}" >&2
+    exit 1
   fi
-elif [[ "$PLATFORM" == "mac" ]]; then
-  DIST_HOST_SRC="obj-${ARCH}-apple-darwin/dist/host"
+  mv -- "${PACKAGE_MATCHES[0]}" "$PACKAGE_DEST"
+elif [[ "$PLATFORM" == "linux" ]]; then
+  PACKAGE_MATCHES=("${OBJDIR}"/dist/floorp-*.tar.xz)
+  if (( ${#PACKAGE_MATCHES[@]} != 1 )); then
+    echo "Expected exactly one Linux package, found ${#PACKAGE_MATCHES[@]}." >&2
+    printf '  %s\n' "${PACKAGE_MATCHES[@]}" >&2
+    exit 1
+  fi
+  mv -- "${PACKAGE_MATCHES[0]}" "$PACKAGE_DEST"
 else
-  DIST_HOST_SRC=""
+  if [[ "$PGO_MODE" == "generate" ]]; then
+    tar -czf "$PACKAGE_DEST" "./${OBJDIR}/"
+  else
+    tar -czf "$PACKAGE_DEST" -C "./${OBJDIR}/dist" .
+  fi
 fi
 
-if [[ -n "$DIST_HOST_SRC" && -d "$DIST_HOST_SRC" ]]; then
-  cp -a "$DIST_HOST_SRC"/. "$DIST_HOST_DEST"/
-else
-  echo "Warning: dist/host directory not found for ${PLATFORM}-${ARCH} (expected ${DIST_HOST_SRC})" >&2
+if [[ ! -s "$PACKAGE_DEST" ]]; then
+  echo "Primary package is missing or empty: ${PACKAGE_DEST}" >&2
+  exit 1
 fi
+
+if [[ ! -d "$DIST_HOST_SRC" ]]; then
+  echo "Required dist/host directory is missing: ${DIST_HOST_SRC}" >&2
+  exit 1
+fi
+if [[ -z "$(find "$DIST_HOST_SRC" -mindepth 1 -print -quit)" ]]; then
+  echo "Required dist/host directory is empty: ${DIST_HOST_SRC}" >&2
+  exit 1
+fi
+cp -a "$DIST_HOST_SRC"/. "$DIST_HOST_DEST"/
+
+APPLICATION_INI_SRC="${OBJDIR}/dist/bin/application.ini"
+if [[ ! -f "$APPLICATION_INI_SRC" ]]; then
+  APPLICATION_INI_MATCHES=()
+  while IFS= read -r -d '' candidate; do
+    APPLICATION_INI_MATCHES+=("$candidate")
+  done < <(find "${OBJDIR}/dist" -type f -path '*/Contents/Resources/application.ini' -print0)
+
+  if (( ${#APPLICATION_INI_MATCHES[@]} != 1 )); then
+    echo "Expected exactly one packaged application.ini, found ${#APPLICATION_INI_MATCHES[@]}." >&2
+    printf '  %s\n' "${APPLICATION_INI_MATCHES[@]}" >&2
+    exit 1
+  fi
+  APPLICATION_INI_SRC="${APPLICATION_INI_MATCHES[0]}"
+fi
+
+APPLICATION_BUILD_ID="$(sed -n 's/^BuildID=//p' "$APPLICATION_INI_SRC" | head -n 1 | tr -d '\r')"
+if [[ ! "$APPLICATION_BUILD_ID" =~ ^[0-9]{14}$ ]]; then
+  echo "Diagnostic application.ini has an invalid BuildID: ${APPLICATION_INI_SRC}" >&2
+  exit 1
+fi
+if [[ "$APPLICATION_BUILD_ID" != "$MOZ_BUILD_DATE" ]]; then
+  echo "Diagnostic application.ini BuildID (${APPLICATION_BUILD_ID}) does not match expected build ID (${MOZ_BUILD_DATE})." >&2
+  exit 1
+fi
+cp -- "$APPLICATION_INI_SRC" "${BUNDLE_DIR}/floorp-application.ini"
+
+echo "Staged consolidated artifact bundle: ${BUNDLE_DIR}"
+echo "Diagnostic application.ini BuildID matches expected build ID: ${MOZ_BUILD_DATE}"

--- a/.github/workflows/scripts/runtime_build_context.py
+++ b/.github/workflows/scripts/runtime_build_context.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+BUILD_ID_RE = re.compile(r"[0-9]{14}\Z")
+CREATED_AT_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\Z")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})/[A-Za-z0-9_.-]{1,100}\Z")
+SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
+POSITIVE_DECIMAL_RE = re.compile(r"[1-9][0-9]{0,19}\Z")
+MAX_RESPONSE_BYTES = 1024 * 1024
+
+
+class BuildContextError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class BuildContext:
+    expected_build_id: str
+    repository: str
+    head_sha: str
+    workflow_run_id: str
+    run_created_at: str
+    run_attempt: str
+
+    def as_outputs(self) -> dict[str, str]:
+        return {
+            "expected-build-id": self.expected_build_id,
+            "repository": self.repository,
+            "head-sha": self.head_sha,
+            "workflow-run-id": self.workflow_run_id,
+            "run-created-at": self.run_created_at,
+            "run-attempt": self.run_attempt,
+        }
+
+
+def validate_build_id(value: str, field: str) -> str:
+    if not isinstance(value, str) or not BUILD_ID_RE.fullmatch(value):
+        raise BuildContextError(f"{field} must be exactly 14 ASCII digits")
+    try:
+        parsed = datetime.strptime(value, "%Y%m%d%H%M%S")
+    except ValueError as exc:
+        raise BuildContextError(f"{field} is not a valid UTC timestamp") from exc
+    if parsed.strftime("%Y%m%d%H%M%S") != value:
+        raise BuildContextError(f"{field} is not canonical")
+    return value
+
+
+def validate_optional_build_id(value: str, field: str) -> str:
+    if value == "":
+        return ""
+    return validate_build_id(value, field)
+
+
+def validate_repository(value: str) -> str:
+    if not isinstance(value, str) or not REPOSITORY_RE.fullmatch(value):
+        raise BuildContextError("repository must be a canonical owner/name value")
+    owner, name = value.split("/", 1)
+    if owner.endswith("-") or "--" in owner or name in {".", ".."}:
+        raise BuildContextError("repository must be a canonical owner/name value")
+    return value
+
+
+def validate_head_sha(value: str) -> str:
+    if not isinstance(value, str) or not SHA_RE.fullmatch(value):
+        raise BuildContextError(
+            "head_sha must be exactly 40 lowercase hexadecimal characters"
+        )
+    return value
+
+
+def validate_positive_decimal(value: str, field: str) -> str:
+    if not isinstance(value, str) or not POSITIVE_DECIMAL_RE.fullmatch(value):
+        raise BuildContextError(f"{field} must be a positive canonical decimal integer")
+    return value
+
+
+def validate_positive_integer(value: Any, field: str) -> int:
+    if type(value) is not int or value <= 0 or len(str(value)) > 20:
+        raise BuildContextError(f"REST {field} must be a positive integer")
+    return value
+
+
+def parse_created_at(value: Any) -> datetime:
+    if not isinstance(value, str) or not CREATED_AT_RE.fullmatch(value):
+        raise BuildContextError(
+            "REST created_at must use canonical UTC YYYY-MM-DDTHH:MM:SSZ"
+        )
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError as exc:
+        raise BuildContextError("REST created_at is not a valid UTC timestamp") from exc
+    if parsed.strftime("%Y-%m-%dT%H:%M:%SZ") != value:
+        raise BuildContextError("REST created_at is not canonical")
+    return parsed
+
+
+def derive_build_id(created_at: str) -> str:
+    return parse_created_at(created_at).strftime("%Y%m%d%H%M%S")
+
+
+def parse_boolean(value: str, field: str) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise BuildContextError(f"{field} must be exactly true or false")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise BuildContextError(
+                f"REST response contains duplicate JSON key {key!r}"
+            )
+        result[key] = value
+    return result
+
+
+def parse_rest_json(data: bytes) -> Mapping[str, Any]:
+    try:
+        text = data.decode("utf-8", errors="strict")
+        value = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=lambda constant: (_ for _ in ()).throw(
+                BuildContextError(
+                    f"REST response contains invalid JSON value {constant}"
+                )
+            ),
+        )
+    except UnicodeDecodeError as exc:
+        raise BuildContextError("REST response is not valid UTF-8") from exc
+    except json.JSONDecodeError as exc:
+        raise BuildContextError("REST response is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise BuildContextError("REST response must be a JSON object")
+    return value
+
+
+def build_run_url(api_url: str, repository: str, workflow_run_id: str) -> str:
+    repository = validate_repository(repository)
+    workflow_run_id = validate_positive_decimal(workflow_run_id, "workflow_run_id")
+    if not isinstance(api_url, str) or api_url == "":
+        raise BuildContextError("GITHUB_API_URL is required for REST resolution")
+    if any(character.isspace() or ord(character) < 0x20 for character in api_url):
+        raise BuildContextError("GITHUB_API_URL contains invalid characters")
+    try:
+        parsed = urllib.parse.urlsplit(api_url)
+        port = parsed.port
+    except ValueError as exc:
+        raise BuildContextError("GITHUB_API_URL is invalid") from exc
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or port is not None
+        and not 1 <= port <= 65535
+    ):
+        raise BuildContextError("GITHUB_API_URL must be an HTTPS API base URL")
+    owner, name = repository.split("/", 1)
+    encoded_repository = "/".join(
+        urllib.parse.quote(part, safe="") for part in (owner, name)
+    )
+    return (
+        f"{api_url.rstrip('/')}/repos/{encoded_repository}/actions/runs/"
+        f"{workflow_run_id}"
+    )
+
+
+def fetch_actions_run(
+    *,
+    api_url: str,
+    repository: str,
+    workflow_run_id: str,
+    github_token: str,
+    timeout: float = 30.0,
+) -> Mapping[str, Any]:
+    if not isinstance(github_token, str) or github_token == "":
+        raise BuildContextError("GITHUB_TOKEN is required for REST resolution")
+    if any(
+        character.isspace() or ord(character) < 0x20 or ord(character) == 0x7F
+        for character in github_token
+    ):
+        raise BuildContextError("GITHUB_TOKEN contains invalid characters")
+    url = build_run_url(api_url, repository, workflow_run_id)
+    request = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {github_token}",
+            "User-Agent": "floorp-runtime-build-context",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            if response.status != 200:
+                raise BuildContextError(
+                    f"Actions run REST request returned HTTP {response.status}"
+                )
+            data = response.read(MAX_RESPONSE_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        raise BuildContextError(
+            f"Actions run REST request returned HTTP {exc.code}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise BuildContextError("Actions run REST request failed") from exc
+    if len(data) > MAX_RESPONSE_BYTES:
+        raise BuildContextError("Actions run REST response is too large")
+    return parse_rest_json(data)
+
+
+def validate_run_payload(
+    payload: Mapping[str, Any],
+    *,
+    repository: str,
+    workflow_run_id: str,
+    head_sha: str,
+    run_attempt: str,
+) -> tuple[str, str]:
+    if not isinstance(payload, Mapping):
+        raise BuildContextError("REST response must be a JSON object")
+    repository = validate_repository(repository)
+    workflow_run_id = validate_positive_decimal(workflow_run_id, "workflow_run_id")
+    head_sha = validate_head_sha(head_sha)
+    run_attempt = validate_positive_decimal(run_attempt, "run_attempt")
+
+    response_repository = payload.get("repository")
+    if not isinstance(response_repository, dict):
+        raise BuildContextError("REST repository must be an object")
+    response_full_name = response_repository.get("full_name")
+    if not isinstance(response_full_name, str):
+        raise BuildContextError("REST repository.full_name must be a string")
+    validate_repository(response_full_name)
+    if response_full_name != repository:
+        raise BuildContextError(
+            "REST repository.full_name does not match GITHUB_REPOSITORY"
+        )
+
+    response_id = validate_positive_integer(payload.get("id"), "id")
+    if str(response_id) != workflow_run_id:
+        raise BuildContextError("REST id does not match GITHUB_RUN_ID")
+
+    response_head_sha = payload.get("head_sha")
+    if not isinstance(response_head_sha, str):
+        raise BuildContextError("REST head_sha must be a string")
+    validate_head_sha(response_head_sha)
+    if response_head_sha != head_sha:
+        raise BuildContextError("REST head_sha does not match GITHUB_SHA")
+
+    response_created_at = payload.get("created_at")
+    parse_created_at(response_created_at)
+
+    response_run_attempt = validate_positive_integer(
+        payload.get("run_attempt"), "run_attempt"
+    )
+    if str(response_run_attempt) != run_attempt:
+        raise BuildContextError("REST run_attempt does not match GITHUB_RUN_ATTEMPT")
+
+    return response_created_at, str(response_run_attempt)
+
+
+def resolve_build_context(
+    *,
+    resolved_moz_build_date: str,
+    requested_moz_build_date: str,
+    require_run_metadata: bool,
+    repository: str,
+    head_sha: str,
+    workflow_run_id: str,
+    run_attempt: str,
+    github_token: str,
+    api_url: str,
+    fetcher: Callable[..., Mapping[str, Any]] | None = None,
+) -> BuildContext:
+    resolved = validate_optional_build_id(
+        resolved_moz_build_date, "resolved_moz_build_date"
+    )
+    requested = validate_optional_build_id(
+        requested_moz_build_date, "requested_moz_build_date"
+    )
+    if resolved and requested and resolved != requested:
+        raise BuildContextError(
+            "resolved_moz_build_date conflicts with requested_moz_build_date"
+        )
+
+    repository = validate_repository(repository)
+    head_sha = validate_head_sha(head_sha)
+    workflow_run_id = validate_positive_decimal(workflow_run_id, "workflow_run_id")
+    run_attempt = validate_positive_decimal(run_attempt, "run_attempt")
+
+    if resolved and not require_run_metadata:
+        return BuildContext(
+            expected_build_id=resolved,
+            repository=repository,
+            head_sha=head_sha,
+            workflow_run_id=workflow_run_id,
+            run_created_at="",
+            run_attempt=run_attempt,
+        )
+
+    active_fetcher = fetcher or fetch_actions_run
+    payload = active_fetcher(
+        api_url=api_url,
+        repository=repository,
+        workflow_run_id=workflow_run_id,
+        github_token=github_token,
+    )
+    created_at, observed_run_attempt = validate_run_payload(
+        payload,
+        repository=repository,
+        workflow_run_id=workflow_run_id,
+        head_sha=head_sha,
+        run_attempt=run_attempt,
+    )
+    expected_build_id = derive_build_id(created_at)
+    for field, asserted_value in (
+        ("resolved_moz_build_date", resolved),
+        ("requested_moz_build_date", requested),
+    ):
+        if asserted_value and asserted_value != expected_build_id:
+            raise BuildContextError(
+                f"{field} does not match the build ID derived from REST created_at"
+            )
+
+    return BuildContext(
+        expected_build_id=expected_build_id,
+        repository=repository,
+        head_sha=head_sha,
+        workflow_run_id=workflow_run_id,
+        run_created_at=created_at,
+        run_attempt=observed_run_attempt,
+    )
+
+
+def write_github_output(path: str, context: BuildContext) -> None:
+    if not isinstance(path, str) or path == "":
+        raise BuildContextError("GITHUB_OUTPUT is required")
+    outputs = context.as_outputs()
+    for key, value in outputs.items():
+        if "\n" in value or "\r" in value:
+            raise BuildContextError(f"output {key} contains a line break")
+    with Path(path).open("a", encoding="utf-8", newline="\n") as output_file:
+        for key, value in outputs.items():
+            output_file.write(f"{key}={value}\n")
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Resolve a Floorp runtime build context"
+    )
+    parser.add_argument(
+        "--resolved-moz-build-date",
+        default=os.environ.get("RESOLVED_MOZ_BUILD_DATE", ""),
+    )
+    parser.add_argument(
+        "--requested-moz-build-date",
+        default=os.environ.get("REQUESTED_MOZ_BUILD_DATE", ""),
+    )
+    parser.add_argument(
+        "--require-run-metadata",
+        default=os.environ.get("REQUIRE_RUN_METADATA", "false"),
+    )
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--head-sha", default=os.environ.get("GITHUB_SHA", ""))
+    parser.add_argument(
+        "--workflow-run-id", default=os.environ.get("GITHUB_RUN_ID", "")
+    )
+    parser.add_argument(
+        "--run-attempt", default=os.environ.get("GITHUB_RUN_ATTEMPT", "")
+    )
+    parser.add_argument(
+        "--api-url", default=os.environ.get("GITHUB_API_URL", "https://api.github.com")
+    )
+    parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = create_argument_parser().parse_args(argv)
+    try:
+        context = resolve_build_context(
+            resolved_moz_build_date=args.resolved_moz_build_date,
+            requested_moz_build_date=args.requested_moz_build_date,
+            require_run_metadata=parse_boolean(
+                args.require_run_metadata, "require_run_metadata"
+            ),
+            repository=args.repository,
+            head_sha=args.head_sha,
+            workflow_run_id=args.workflow_run_id,
+            run_attempt=args.run_attempt,
+            github_token=os.environ.get("GITHUB_TOKEN", ""),
+            api_url=args.api_url,
+        )
+        write_github_output(args.github_output, context)
+    except (BuildContextError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"Resolved build context for {context.repository} run "
+        f"{context.workflow_run_id} attempt {context.run_attempt}: "
+        f"{context.expected_build_id}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/scripts/test_runtime_build_context.py
+++ b/.github/workflows/scripts/test_runtime_build_context.py
@@ -1,0 +1,618 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+import runtime_build_context as build_context
+
+REPOSITORY = "Floorp-Projects/Floorp-Runtime"
+HEAD_SHA = "0123456789abcdef0123456789abcdef01234567"
+WORKFLOW_RUN_ID = "123456789"
+CREATED_AT = "2026-07-23T01:02:03Z"
+EXPECTED_BUILD_ID = "20260723010203"
+
+
+def run_payload(
+    *,
+    repository: object = REPOSITORY,
+    run_id: object = 123456789,
+    head_sha: object = HEAD_SHA,
+    created_at: object = CREATED_AT,
+    run_attempt: object = 2,
+) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "repository": {"full_name": repository},
+        "head_sha": head_sha,
+        "created_at": created_at,
+        "run_attempt": run_attempt,
+    }
+
+
+def resolve(**overrides: object) -> build_context.BuildContext:
+    arguments: dict[str, object] = {
+        "resolved_moz_build_date": "",
+        "requested_moz_build_date": "",
+        "require_run_metadata": False,
+        "repository": REPOSITORY,
+        "head_sha": HEAD_SHA,
+        "workflow_run_id": WORKFLOW_RUN_ID,
+        "run_attempt": "2",
+        "github_token": "token",
+        "api_url": "https://api.github.com",
+        "fetcher": lambda **_kwargs: run_payload(),
+    }
+    arguments.update(overrides)
+    return build_context.resolve_build_context(**arguments)
+
+
+class ValidationTests(unittest.TestCase):
+    def test_build_id_accepts_valid_leap_day(self) -> None:
+        self.assertEqual(
+            build_context.validate_build_id("20240229235959", "value"),
+            "20240229235959",
+        )
+
+    def test_build_id_rejects_noncanonical_or_invalid_values(self) -> None:
+        invalid_values = (
+            "",
+            "2026072301020",
+            "202607230102030",
+            "２０２６０７２３０１０２０３",
+            "20260229010203",
+            "20261301010203",
+            "20260723240203",
+            "20260723016003",
+            "20260723010260",
+            " 20260723010203",
+        )
+        for value in invalid_values:
+            with self.subTest(value=value), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                build_context.validate_build_id(value, "value")
+
+    def test_created_at_is_strict_utc_and_derives_build_id(self) -> None:
+        self.assertEqual(build_context.derive_build_id(CREATED_AT), EXPECTED_BUILD_ID)
+        invalid_values = (
+            "2026-07-23T01:02:03+00:00",
+            "2026-07-23T01:02:03.000Z",
+            "2026-07-23 01:02:03Z",
+            "2026-07-23T24:02:03Z",
+            "2026-02-29T01:02:03Z",
+            "２０２６-07-23T01:02:03Z",
+        )
+        for value in invalid_values:
+            with self.subTest(value=value), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                build_context.derive_build_id(value)
+
+    def test_context_identifiers_are_strict(self) -> None:
+        for repository in (
+            "Floorp-Projects",
+            "Floorp-Projects/Floorp-Runtime/extra",
+            "Floorp--Projects/Floorp-Runtime",
+            "Floorp-Projects-/Floorp-Runtime",
+            "Floorp Projects/Floorp-Runtime",
+            "Floorp-Projects/..",
+        ):
+            with self.subTest(repository=repository), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                build_context.validate_repository(repository)
+        for sha in (HEAD_SHA.upper(), HEAD_SHA[:-1], f"g{HEAD_SHA[1:]}"):
+            with self.subTest(sha=sha), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                build_context.validate_head_sha(sha)
+        for number in ("", "0", "01", "+1", "-1", "1 ", "1" * 21):
+            with self.subTest(number=number), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                build_context.validate_positive_decimal(number, "number")
+
+    def test_boolean_is_not_truthy_coerced(self) -> None:
+        self.assertTrue(build_context.parse_boolean("true", "flag"))
+        self.assertFalse(build_context.parse_boolean("false", "flag"))
+        for value in ("True", "FALSE", "1", "", " true"):
+            with self.subTest(value=value), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                build_context.parse_boolean(value, "flag")
+
+
+class ResolutionTests(unittest.TestCase):
+    def test_trusted_resolved_value_avoids_rest(self) -> None:
+        def forbidden_fetcher(**_kwargs: object) -> dict[str, object]:
+            self.fail("trusted resolution must not call REST")
+
+        context = resolve(
+            resolved_moz_build_date=EXPECTED_BUILD_ID,
+            requested_moz_build_date=EXPECTED_BUILD_ID,
+            github_token="",
+            fetcher=forbidden_fetcher,
+        )
+        self.assertEqual(
+            context.as_outputs(),
+            {
+                "expected-build-id": EXPECTED_BUILD_ID,
+                "repository": REPOSITORY,
+                "head-sha": HEAD_SHA,
+                "workflow-run-id": WORKFLOW_RUN_ID,
+                "run-created-at": "",
+                "run-attempt": "2",
+            },
+        )
+
+    def test_conflicting_trusted_and_requested_values_fail_before_rest(self) -> None:
+        def forbidden_fetcher(**_kwargs: object) -> dict[str, object]:
+            self.fail("conflicting assertions must fail before REST")
+
+        with self.assertRaisesRegex(build_context.BuildContextError, "conflicts with"):
+            resolve(
+                resolved_moz_build_date=EXPECTED_BUILD_ID,
+                requested_moz_build_date="20260723010204",
+                require_run_metadata=True,
+                fetcher=forbidden_fetcher,
+            )
+
+    def test_missing_resolved_value_uses_rest(self) -> None:
+        observed: list[dict[str, object]] = []
+
+        def fetcher(**kwargs: object) -> dict[str, object]:
+            observed.append(kwargs)
+            return run_payload()
+
+        context = resolve(fetcher=fetcher)
+        self.assertEqual(context.expected_build_id, EXPECTED_BUILD_ID)
+        self.assertEqual(context.run_created_at, CREATED_AT)
+        self.assertEqual(context.run_attempt, "2")
+        self.assertEqual(
+            observed,
+            [
+                {
+                    "api_url": "https://api.github.com",
+                    "repository": REPOSITORY,
+                    "workflow_run_id": WORKFLOW_RUN_ID,
+                    "github_token": "token",
+                }
+            ],
+        )
+
+    def test_require_metadata_forces_rest_and_checks_resolved_assertion(self) -> None:
+        context = resolve(
+            resolved_moz_build_date=EXPECTED_BUILD_ID,
+            require_run_metadata=True,
+        )
+        self.assertEqual(context.run_created_at, CREATED_AT)
+        with self.assertRaisesRegex(
+            build_context.BuildContextError, "resolved_moz_build_date does not match"
+        ):
+            resolve(
+                resolved_moz_build_date="20260723010204",
+                require_run_metadata=True,
+            )
+
+    def test_requested_value_is_only_an_assertion(self) -> None:
+        self.assertEqual(
+            resolve(requested_moz_build_date=EXPECTED_BUILD_ID).expected_build_id,
+            EXPECTED_BUILD_ID,
+        )
+        with self.assertRaisesRegex(
+            build_context.BuildContextError, "requested_moz_build_date does not match"
+        ):
+            resolve(requested_moz_build_date="20260723010204")
+
+    def test_run_attempt_is_observed_but_does_not_change_identity(self) -> None:
+        first = resolve(
+            run_attempt="1", fetcher=lambda **_kwargs: run_payload(run_attempt=1)
+        )
+        second = resolve(
+            run_attempt="2", fetcher=lambda **_kwargs: run_payload(run_attempt=2)
+        )
+        self.assertEqual(first.expected_build_id, second.expected_build_id)
+        self.assertEqual(first.run_attempt, "1")
+        self.assertEqual(second.run_attempt, "2")
+
+    def test_daily_manifest_uses_aggregate_attempt_on_rerun(self) -> None:
+        preserved_resolver = resolve(
+            run_attempt="1", fetcher=lambda **_kwargs: run_payload(run_attempt=1)
+        )
+        aggregate_attempt = "2"
+        self.assertEqual(preserved_resolver.run_attempt, "1")
+        self.assertEqual(preserved_resolver.expected_build_id, EXPECTED_BUILD_ID)
+        self.assertEqual(aggregate_attempt, "2")
+
+        workflow = (
+            Path(__file__).resolve().parents[1] / "daily-build.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "MANIFEST_RUN_ATTEMPT: ${{ github.run_attempt }}",
+            workflow,
+        )
+        self.assertNotIn(
+            "needs.resolve-build-context.outputs.run-attempt",
+            workflow,
+        )
+
+    def test_daily_validation_only_runs_manifest_without_publish_side_effects(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[1] / "daily-build.yml"
+        ).read_text(encoding="utf-8")
+        android = workflow.split("  android:", 1)[1].split(
+            "  verify-windows-x86_64:", 1
+        )[0]
+        aggregate = workflow.split("  aggregate-runtime-manifest-v2:", 1)[1].split(
+            "  publish-debug-to-core-ftp:", 1
+        )[0]
+        debug_publish = workflow.split("  publish-debug-to-core-ftp:", 1)[1].split(
+            "  publish-release:", 1
+        )[0]
+        release_publish = workflow.split("  publish-release:", 1)[1]
+
+        validation_input = workflow.split("      validation_only:", 1)[1].split(
+            "      requested_MOZ_BUILD_DATE:", 1
+        )[0]
+        self.assertIn("type: boolean", validation_input)
+        self.assertIn("default: false", validation_input)
+        self.assertEqual(workflow.count("inputs.validation_only != true"), 3)
+        self.assertIn("if: ${{ inputs.validation_only != true }}", android)
+        self.assertIn("inputs.validation_only == true", aggregate)
+        self.assertIn("github.event.inputs.debug != 'true'", aggregate)
+        self.assertNotIn("aggregate-runtime-manifest-v2", debug_publish)
+        self.assertIn("inputs.validation_only != true", debug_publish)
+        self.assertIn(
+            "needs: [aggregate-runtime-manifest-v2, android]",
+            release_publish,
+        )
+        self.assertIn("inputs.validation_only != true", release_publish)
+
+    def test_daily_runtime_verifier_matrix_and_publish_gates(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[1] / "daily-build.yml"
+        ).read_text(encoding="utf-8")
+        verifier_specs = [
+            (
+                "verify-windows-x86_64",
+                "windows-x86_64",
+                "Windows",
+                "x86_64",
+                "windows-2025",
+            ),
+            (
+                "verify-linux-x86_64",
+                "linux-x86_64",
+                "Linux",
+                "x86_64",
+                "ubuntu-24.04",
+            ),
+            (
+                "verify-linux-aarch64",
+                "linux-aarch64",
+                "Linux",
+                "aarch64",
+                "ubuntu-24.04-arm",
+            ),
+            (
+                "verify-mac-x86_64",
+                "mac",
+                "Darwin",
+                "x86_64",
+                "macos-15-intel",
+            ),
+            (
+                "verify-mac-aarch64",
+                "mac",
+                "Darwin",
+                "aarch64",
+                "macos-14",
+            ),
+        ]
+
+        def job_block(job: str) -> str:
+            marker = f"  {job}:"
+            self.assertEqual(workflow.count(marker), 1)
+            lines = workflow.split(marker, 1)[1].splitlines()[1:]
+            block_lines = []
+            for line in lines:
+                if line.startswith("  ") and not line.startswith("    "):
+                    break
+                block_lines.append(line)
+            return "\n".join(block_lines)
+
+        def setting(block: str, name: str) -> str:
+            prefix = f"{name}:"
+            values = [
+                line.strip().removeprefix(prefix).strip()
+                for line in block.splitlines()
+                if line.strip().startswith(prefix)
+            ]
+            self.assertEqual(len(values), 1, name)
+            return values[0]
+
+        actual_specs = []
+
+        for job, build, platform, arch, runner in verifier_specs:
+            block = job_block(job)
+            actual_specs.append(
+                (
+                    job,
+                    setting(block, "needs"),
+                    setting(block, "platform"),
+                    setting(block, "arch"),
+                    setting(block, "runner"),
+                )
+            )
+            self.assertIn(f"needs: {build}", block)
+            self.assertIn("uses: ./.github/workflows/verify-runtime-artifact.yml", block)
+            for input_name, output_name in (
+                ("artifact-id", "artifact-id"),
+                ("artifact-name", "artifact-name"),
+                ("expected-build-id", "expected-build-id"),
+            ):
+                self.assertIn(
+                    f"{input_name}: ${{{{ needs.{build}.outputs.{output_name} }}}}",
+                    block,
+                )
+            self.assertIn(f"platform: {platform}", block)
+            self.assertIn(f"arch: {arch}", block)
+            self.assertIn(f"runner: {runner}", block)
+
+        self.assertEqual(actual_specs, verifier_specs)
+
+        def list_needs(block: str) -> list[str]:
+            lines = block.splitlines()
+            start = lines.index("    needs:") + 1
+            needs = []
+            for line in lines[start:]:
+                if not line.startswith("      - "):
+                    break
+                needs.append(line.removeprefix("      - "))
+            return needs
+
+        verifier_jobs = [job for job, *_rest in verifier_specs]
+        self.assertEqual(
+            list_needs(job_block("aggregate-runtime-manifest-v2")),
+            [
+                "resolve-build-context",
+                "windows-x86_64",
+                "linux-x86_64",
+                "linux-aarch64",
+                "mac",
+                *verifier_jobs,
+            ],
+        )
+        self.assertEqual(
+            list_needs(job_block("publish-debug-to-core-ftp")),
+            [
+                "windows-x86_64",
+                "linux-x86_64",
+                "linux-aarch64",
+                "mac",
+                "android",
+                *verifier_jobs,
+            ],
+        )
+
+    def test_linux_stage2_uses_retained_profile_generation_artifact(self) -> None:
+        workflows = Path(__file__).resolve().parents[1]
+        common = (workflows / "common-build.yml").read_text(encoding="utf-8")
+        wrapper = (workflows / "wrapper-build-linux.yml").read_text(
+            encoding="utf-8"
+        )
+        artifact_name = "floorp-linux-x86_64-profile-generate-mode-package"
+        self.assertIn("Upload PGO profile generation package (Linux)", common)
+        self.assertIn(f"name: {artifact_name}", common)
+        self.assertIn(f"browser-artifact-name: >-\n        {artifact_name}", wrapper)
+
+    def test_rest_payload_must_match_all_trusted_context_fields(self) -> None:
+        mismatches = {
+            "repository": run_payload(repository="Floorp-Projects/Other"),
+            "id": run_payload(run_id=123456788),
+            "head_sha": run_payload(head_sha="f" * 40),
+            "run_attempt": run_payload(run_attempt=1),
+        }
+        for field, payload in mismatches.items():
+            with self.subTest(field=field), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                resolve(fetcher=lambda **_kwargs: payload)
+
+    def test_rest_payload_rejects_missing_and_wrong_field_types(self) -> None:
+        fields = ("repository", "id", "head_sha", "created_at", "run_attempt")
+        for field in fields:
+            payload = run_payload()
+            del payload[field]
+            with self.subTest(missing=field), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                resolve(fetcher=lambda **_kwargs: payload)
+
+        wrong_values = {
+            "repository": {"full_name": 123},
+            "id": True,
+            "head_sha": 123,
+            "created_at": 123,
+            "run_attempt": True,
+        }
+        for field, value in wrong_values.items():
+            payload = run_payload()
+            payload[field] = value
+            with self.subTest(wrong_type=field), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                resolve(fetcher=lambda **_kwargs: payload)
+
+    def test_trusted_path_still_validates_github_context(self) -> None:
+        invalid_cases = {
+            "repository": "Floorp-Projects",
+            "head_sha": HEAD_SHA.upper(),
+            "workflow_run_id": "0",
+            "run_attempt": "01",
+        }
+        for field, value in invalid_cases.items():
+            with self.subTest(field=field), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                resolve(resolved_moz_build_date=EXPECTED_BUILD_ID, **{field: value})
+
+
+class RestClientTests(unittest.TestCase):
+    def test_json_parser_rejects_duplicates_constants_and_non_objects(self) -> None:
+        invalid_documents = (
+            b'{"id": 1, "id": 2}',
+            b'{"id": NaN}',
+            b"[]",
+            b"\xff",
+            b"not-json",
+        )
+        for document in invalid_documents:
+            with self.subTest(document=document), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                build_context.parse_rest_json(document)
+
+    def test_run_url_supports_github_enterprise_api_base(self) -> None:
+        self.assertEqual(
+            build_context.build_run_url(
+                "https://github.example/api/v3/", REPOSITORY, WORKFLOW_RUN_ID
+            ),
+            "https://github.example/api/v3/repos/"
+            "Floorp-Projects/Floorp-Runtime/actions/runs/123456789",
+        )
+        for url in (
+            "",
+            "http://api.github.com",
+            "https://user@example.com",
+            "https://api.github.com?query=1",
+            "https://api.github.com/#fragment",
+            " https://api.github.com",
+        ):
+            with self.subTest(url=url), self.assertRaises(
+                build_context.BuildContextError
+            ):
+                build_context.build_run_url(url, REPOSITORY, WORKFLOW_RUN_ID)
+
+    def test_fetch_uses_authenticated_versioned_get_and_parses_json(self) -> None:
+        response_body = json.dumps(run_payload()).encode("utf-8")
+
+        class Response:
+            status = 200
+
+            def __enter__(self) -> Response:
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self, _size: int) -> bytes:
+                return response_body
+
+        with mock.patch.object(
+            build_context.urllib.request, "urlopen", return_value=Response()
+        ) as urlopen:
+            payload = build_context.fetch_actions_run(
+                api_url="https://api.github.com",
+                repository=REPOSITORY,
+                workflow_run_id=WORKFLOW_RUN_ID,
+                github_token="secret-token",
+            )
+        self.assertEqual(payload["created_at"], CREATED_AT)
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.method, "GET")
+        self.assertEqual(request.get_header("Authorization"), "Bearer secret-token")
+        self.assertEqual(request.get_header("Accept"), "application/vnd.github+json")
+        self.assertEqual(request.get_header("X-github-api-version"), "2022-11-28")
+        self.assertEqual(urlopen.call_args.kwargs, {"timeout": 30.0})
+
+    def test_fetch_fails_closed_without_token_or_on_http_error(self) -> None:
+        with self.assertRaisesRegex(
+            build_context.BuildContextError, "TOKEN is required"
+        ):
+            build_context.fetch_actions_run(
+                api_url="https://api.github.com",
+                repository=REPOSITORY,
+                workflow_run_id=WORKFLOW_RUN_ID,
+                github_token="",
+            )
+        error = urllib.error.HTTPError(
+            "https://api.github.com", 403, "Forbidden", {}, None
+        )
+        with mock.patch.object(
+            build_context.urllib.request, "urlopen", side_effect=error
+        ):
+            with self.assertRaisesRegex(build_context.BuildContextError, "HTTP 403"):
+                build_context.fetch_actions_run(
+                    api_url="https://api.github.com",
+                    repository=REPOSITORY,
+                    workflow_run_id=WORKFLOW_RUN_ID,
+                    github_token="token",
+                )
+
+
+class CliTests(unittest.TestCase):
+    def test_trusted_cli_writes_exact_github_outputs_without_token(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "github-output"
+            with mock.patch.dict(os.environ, {}, clear=True):
+                result = build_context.main([
+                    "--resolved-moz-build-date",
+                    EXPECTED_BUILD_ID,
+                    "--requested-moz-build-date",
+                    EXPECTED_BUILD_ID,
+                    "--require-run-metadata",
+                    "false",
+                    "--repository",
+                    REPOSITORY,
+                    "--head-sha",
+                    HEAD_SHA,
+                    "--workflow-run-id",
+                    WORKFLOW_RUN_ID,
+                    "--run-attempt",
+                    "2",
+                    "--github-output",
+                    str(output_path),
+                ])
+            self.assertEqual(result, 0)
+            self.assertEqual(
+                output_path.read_text(encoding="utf-8"),
+                f"expected-build-id={EXPECTED_BUILD_ID}\n"
+                f"repository={REPOSITORY}\n"
+                f"head-sha={HEAD_SHA}\n"
+                f"workflow-run-id={WORKFLOW_RUN_ID}\n"
+                "run-created-at=\n"
+                "run-attempt=2\n",
+            )
+
+    def test_cli_failure_does_not_write_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = Path(temporary_directory) / "github-output"
+            with mock.patch.dict(os.environ, {}, clear=True):
+                result = build_context.main([
+                    "--resolved-moz-build-date",
+                    "invalid",
+                    "--repository",
+                    REPOSITORY,
+                    "--head-sha",
+                    HEAD_SHA,
+                    "--workflow-run-id",
+                    WORKFLOW_RUN_ID,
+                    "--run-attempt",
+                    "2",
+                    "--github-output",
+                    str(output_path),
+                ])
+            self.assertEqual(result, 1)
+            self.assertFalse(output_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/scripts/test_verify_full_version.py
+++ b/.github/workflows/scripts/test_verify_full_version.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import verify_full_version as verifier
+
+
+EXPECTED = "20260723010203"
+
+
+class FullVersionParserTests(unittest.TestCase):
+    def test_accepts_exact_adjacent_application_and_platform_ids(self) -> None:
+        identity = verifier.verify_full_version(
+            f"Floorp 153.0 {EXPECTED} {EXPECTED}, Mozilla\n", EXPECTED
+        )
+        self.assertEqual(identity.application_build_id, EXPECTED)
+        self.assertEqual(identity.platform_build_id, EXPECTED)
+
+    def test_accepts_line_break_as_adjacency(self) -> None:
+        identity = verifier.verify_full_version(
+            f"Floorp 153.0 {EXPECTED}\n{EXPECTED}\n", EXPECTED
+        )
+        self.assertEqual(identity.application_build_id, EXPECTED)
+
+    def test_rejects_empty_or_missing_ids(self) -> None:
+        for output in ("", "Floorp 153.0", f"Floorp 153.0 {EXPECTED}"):
+            with self.subTest(output=output), self.assertRaises(
+                verifier.FullVersionError
+            ):
+                verifier.verify_full_version(output, EXPECTED)
+
+    def test_rejects_nonadjacent_ids(self) -> None:
+        with self.assertRaisesRegex(verifier.FullVersionError, "adjacent"):
+            verifier.verify_full_version(
+                f"Floorp {EXPECTED} separator {EXPECTED}", EXPECTED
+            )
+
+    def test_rejects_extra_build_id(self) -> None:
+        with self.assertRaisesRegex(verifier.FullVersionError, "exactly two"):
+            verifier.verify_full_version(
+                f"Floorp {EXPECTED} {EXPECTED} 20260723010204", EXPECTED
+            )
+
+    def test_rejects_application_or_platform_mismatch(self) -> None:
+        for output in (
+            f"Floorp 20260723010204 {EXPECTED}",
+            f"Floorp {EXPECTED} 20260723010204",
+        ):
+            with self.subTest(output=output), self.assertRaises(
+                verifier.FullVersionError
+            ):
+                verifier.verify_full_version(output, EXPECTED)
+
+    def test_does_not_parse_ids_embedded_in_longer_numbers(self) -> None:
+        with self.assertRaisesRegex(verifier.FullVersionError, "exactly two"):
+            verifier.verify_full_version(
+                f"Floorp 1{EXPECTED} {EXPECTED}", EXPECTED
+            )
+
+    def test_expected_build_id_is_strict_and_calendar_valid(self) -> None:
+        for expected in ("", "20260230010203", "２０２６０７２３０１０２０３"):
+            with self.subTest(expected=expected), self.assertRaises(
+                verifier.FullVersionError
+            ):
+                verifier.verify_full_version(
+                    f"Floorp {EXPECTED} {EXPECTED}", expected
+                )
+
+    def test_cli_reads_utf8_file_and_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "full-version.txt"
+            output.write_text(
+                f"Floorp 153.0 {EXPECTED} {EXPECTED}\n", encoding="utf-8"
+            )
+            self.assertEqual(
+                verifier.main(
+                    [
+                        "--expected-build-id",
+                        EXPECTED,
+                        "--output-file",
+                        str(output),
+                    ]
+                ),
+                0,
+            )
+            output.write_text(f"Floorp {EXPECTED}\n", encoding="utf-8")
+            self.assertEqual(
+                verifier.main(
+                    [
+                        "--expected-build-id",
+                        EXPECTED,
+                        "--output-file",
+                        str(output),
+                    ]
+                ),
+                1,
+            )
+
+    def test_workflow_uses_immutable_download_and_static_app_data(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[1] / "verify-runtime-artifact.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("source-workflow-run-id:", workflow)
+        self.assertIn("if: inputs.source-workflow-run-id != ''", workflow)
+        self.assertIn("github.rest.actions.getWorkflowRun", workflow)
+        self.assertIn("github.rest.actions.listWorkflowRunArtifacts", workflow)
+        self.assertIn('run.created_at.replace(/[-:TZ]/g, "")', workflow)
+        self.assertIn("selected source artifact is expired", workflow)
+        self.assertIn("artifact-ids: ${{ inputs.artifact-id }}", workflow)
+        self.assertIn("merge-multiple: true", workflow)
+        self.assertIn("run-id: ${{ inputs.source-workflow-run-id || github.run_id }}", workflow)
+        self.assertIn("actions: read", workflow)
+        self.assertIn("Environment.Remove('XUL_APP_FILE')", workflow)
+        self.assertGreaterEqual(workflow.count("unset XUL_APP_FILE"), 2)
+        self.assertIn("subprocess.run(", workflow)
+        self.assertIn("timeout=30", workflow)
+        self.assertNotIn('full_version="$("$app_binary" --full-version', workflow)
+        self.assertNotIn(" -app ", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/scripts/verify_full_version.py
+++ b/.github/workflows/scripts/verify_full_version.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+BUILD_ID_RE = re.compile(r"(?<![0-9])[0-9]{14}(?![0-9])")
+BUILD_ID_PAIR_RE = re.compile(
+    r"(?<![0-9])(?P<application>[0-9]{14})\s+"
+    r"(?P<platform>[0-9]{14})(?![0-9])"
+)
+MAX_OUTPUT_BYTES = 1024 * 1024
+
+
+class FullVersionError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class FullVersionIdentity:
+    application_build_id: str
+    platform_build_id: str
+
+
+def validate_expected_build_id(value: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9]{14}", value):
+        raise FullVersionError("expected build ID must be exactly 14 ASCII digits")
+    try:
+        parsed = datetime.strptime(value, "%Y%m%d%H%M%S")
+    except ValueError as exc:
+        raise FullVersionError("expected build ID must be a valid UTC timestamp") from exc
+    if parsed.strftime("%Y%m%d%H%M%S") != value:
+        raise FullVersionError("expected build ID must be canonical")
+    return value
+
+
+def parse_full_version(output: str) -> FullVersionIdentity:
+    if not isinstance(output, str) or not output.strip():
+        raise FullVersionError("--full-version output must not be empty")
+
+    build_ids = BUILD_ID_RE.findall(output)
+    if len(build_ids) != 2:
+        raise FullVersionError(
+            "--full-version output must contain exactly two 14-digit build IDs; "
+            f"found {len(build_ids)}"
+        )
+
+    pairs = list(BUILD_ID_PAIR_RE.finditer(output))
+    if len(pairs) != 1:
+        raise FullVersionError(
+            "--full-version output must contain exactly one adjacent "
+            f"application/platform build ID pair; found {len(pairs)}"
+        )
+
+    pair = pairs[0]
+    return FullVersionIdentity(
+        application_build_id=pair.group("application"),
+        platform_build_id=pair.group("platform"),
+    )
+
+
+def verify_full_version(output: str, expected_build_id: str) -> FullVersionIdentity:
+    expected = validate_expected_build_id(expected_build_id)
+    identity = parse_full_version(output)
+    if identity.application_build_id != expected:
+        raise FullVersionError(
+            "application build ID mismatch: "
+            f"expected {expected}, got {identity.application_build_id}"
+        )
+    if identity.platform_build_id != expected:
+        raise FullVersionError(
+            "platform build ID mismatch: "
+            f"expected {expected}, got {identity.platform_build_id}"
+        )
+    return identity
+
+
+def read_output(path: Path) -> str:
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise FullVersionError(f"could not read --full-version output: {exc}") from exc
+    if len(data) > MAX_OUTPUT_BYTES:
+        raise FullVersionError("--full-version output exceeds 1 MiB")
+    try:
+        return data.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise FullVersionError("--full-version output is not valid UTF-8") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify native Floorp --full-version build IDs"
+    )
+    parser.add_argument("--expected-build-id", required=True)
+    parser.add_argument("--output-file", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        identity = verify_full_version(
+            read_output(args.output_file), args.expected_build_id
+        )
+    except FullVersionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "Verified native --full-version identity: "
+        f"application={identity.application_build_id} "
+        f"platform={identity.platform_build_id}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/verify-runtime-artifact.yml
+++ b/.github/workflows/verify-runtime-artifact.yml
@@ -1,0 +1,497 @@
+---
+# SPDX-License-Identifier: MPL-2.0
+
+name: Verify Final Runtime Artifact
+
+'on':
+  workflow_call:
+    inputs:
+      source-workflow-run-id:
+        description: Optional source run ID; blank verifies this workflow run
+        type: string
+        required: false
+        default: ''
+      artifact-id:
+        description: Immutable final primary artifact ID
+        type: string
+        required: true
+      artifact-name:
+        description: Expected final primary artifact name
+        type: string
+        required: true
+      expected-build-id:
+        description: Expected 14-digit application and platform build ID
+        type: string
+        required: true
+      platform:
+        description: Target platform (Windows, Linux, or Darwin)
+        type: string
+        required: true
+      arch:
+        description: Native slice architecture
+        type: string
+        required: true
+      runner:
+        description: Native GitHub-hosted runner label
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      source-workflow-run-id:
+        description: Source Actions workflow run ID containing the artifact
+        type: string
+        required: true
+      artifact-id:
+        description: Immutable final primary artifact ID
+        type: string
+        required: true
+      artifact-name:
+        description: Expected final primary artifact name
+        type: string
+        required: true
+      expected-build-id:
+        description: Expected 14-digit BuildID derived from source run created_at
+        type: string
+        required: true
+      platform:
+        description: Target platform
+        type: choice
+        required: true
+        options:
+          - Windows
+          - Linux
+          - Darwin
+      arch:
+        description: Native slice architecture
+        type: choice
+        required: true
+        options:
+          - x86_64
+          - aarch64
+      runner:
+        description: Native runner matching platform and architecture
+        type: choice
+        required: true
+        options:
+          - windows-2025
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15-intel
+          - macos-14
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  verify:
+    name: Verify ${{ inputs.platform }}/${{ inputs.arch }} final runtime
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
+    steps:
+      - name: Validate immutable verifier contract
+        uses: actions/github-script@v7
+        env:
+          SOURCE_RUN_ID: ${{ inputs.source-workflow-run-id || github.run_id }}
+          ARTIFACT_ID: ${{ inputs.artifact-id }}
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          EXPECTED_BUILD_ID: ${{ inputs.expected-build-id }}
+          TARGET_PLATFORM: ${{ inputs.platform }}
+          TARGET_ARCH: ${{ inputs.arch }}
+          TARGET_RUNNER: ${{ inputs.runner }}
+        with:
+          script: |
+            const contracts = new Map([
+              ["Windows/x86_64", {
+                runner: "windows-2025",
+                artifact: "floorp-windows-x86_64-moz-artifact",
+              }],
+              ["Linux/x86_64", {
+                runner: "ubuntu-24.04",
+                artifact: "floorp-linux-x86_64-moz-artifact",
+              }],
+              ["Linux/aarch64", {
+                runner: "ubuntu-24.04-arm",
+                artifact: "floorp-linux-aarch64-moz-artifact",
+              }],
+              ["Darwin/x86_64", {
+                runner: "macos-15-intel",
+                artifact: "floorp-mac-universal-moz-artifact",
+              }],
+              ["Darwin/aarch64", {
+                runner: "macos-14",
+                artifact: "floorp-mac-universal-moz-artifact",
+              }],
+            ]);
+
+            const positiveId = /^[1-9][0-9]*$/;
+            for (const [name, value] of [
+              ["source workflow run ID", process.env.SOURCE_RUN_ID],
+              ["artifact ID", process.env.ARTIFACT_ID],
+            ]) {
+              if (!positiveId.test(value)) {
+                core.setFailed(`${name} must be a positive decimal integer`);
+                return;
+              }
+              if (!Number.isSafeInteger(Number(value))) {
+                core.setFailed(`${name} exceeds JavaScript's safe integer range`);
+                return;
+              }
+            }
+            if (!/^[0-9]{14}$/.test(process.env.EXPECTED_BUILD_ID)) {
+              core.setFailed("expected build ID must be exactly 14 ASCII digits");
+              return;
+            }
+
+            const key = `${process.env.TARGET_PLATFORM}/${process.env.TARGET_ARCH}`;
+            const contract = contracts.get(key);
+            if (!contract) {
+              core.setFailed(`unsupported native verifier target: ${key}`);
+              return;
+            }
+            if (process.env.TARGET_RUNNER !== contract.runner) {
+              core.setFailed(
+                `${key} requires ${contract.runner}, got ${process.env.TARGET_RUNNER}`
+              );
+              return;
+            }
+            if (process.env.ARTIFACT_NAME !== contract.artifact) {
+              core.setFailed(
+                `${key} requires artifact ${contract.artifact}, got ` +
+                  process.env.ARTIFACT_NAME
+              );
+            }
+
+      - name: Validate manually selected source provenance
+        if: inputs.source-workflow-run-id != ''
+        uses: actions/github-script@v7
+        env:
+          SOURCE_RUN_ID: ${{ inputs.source-workflow-run-id }}
+          ARTIFACT_ID: ${{ inputs.artifact-id }}
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          EXPECTED_BUILD_ID: ${{ inputs.expected-build-id }}
+        with:
+          script: |
+            const sourceRunId = Number(process.env.SOURCE_RUN_ID);
+            const artifactId = Number(process.env.ARTIFACT_ID);
+            const {data: run} = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: sourceRunId,
+            });
+            if (run.id !== sourceRunId) {
+              core.setFailed("REST workflow run ID mismatch");
+              return;
+            }
+            if (run.repository?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed("REST workflow repository mismatch");
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/.test(run.head_sha || "")) {
+              core.setFailed("REST workflow head SHA is malformed");
+              return;
+            }
+            if (!Number.isInteger(run.run_attempt) || run.run_attempt < 1) {
+              core.setFailed("REST workflow run attempt is malformed");
+              return;
+            }
+            if (!/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/.test(run.created_at || "")) {
+              core.setFailed("REST workflow created_at is malformed");
+              return;
+            }
+            const derivedBuildId = run.created_at.replace(/[-:TZ]/g, "");
+            if (derivedBuildId !== process.env.EXPECTED_BUILD_ID) {
+              core.setFailed(
+                `expected BuildID ${process.env.EXPECTED_BUILD_ID} does not match ` +
+                  `source run created_at BuildID ${derivedBuildId}`
+              );
+              return;
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: sourceRunId,
+                per_page: 100,
+              }
+            );
+            const matches = artifacts.filter(artifact => artifact.id === artifactId);
+            if (matches.length !== 1) {
+              core.setFailed("artifact ID is not unique in the selected source run");
+              return;
+            }
+            if (matches[0].name !== process.env.ARTIFACT_NAME) {
+              core.setFailed(
+                `REST artifact name ${matches[0].name} does not match ` +
+                  process.env.ARTIFACT_NAME
+              );
+              return;
+            }
+            if (matches[0].expired) {
+              core.setFailed("selected source artifact is expired");
+            }
+
+      - name: Checkout native identity parser
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/workflows/scripts/verify_full_version.py
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Download exact final primary artifact by ID
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ inputs.artifact-id }}
+          path: ${{ runner.temp }}/runtime-artifact
+          merge-multiple: true
+          run-id: ${{ inputs.source-workflow-run-id || github.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify Windows final runtime natively
+        if: inputs.platform == 'Windows'
+        shell: pwsh
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/runtime-artifact
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          EXPECTED_BUILD_ID: ${{ inputs.expected-build-id }}
+          OUTPUT_FILE: ${{ runner.temp }}/native-full-version.txt
+          PARSER_PATH: ${{ github.workspace }}/.github/workflows/scripts/verify_full_version.py
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:RUNNER_ARCH -ne 'X64') {
+            throw "Expected a native X64 runner, got $env:RUNNER_ARCH"
+          }
+
+          $expectedPackage = Join-Path $env:ARTIFACT_DIR "$env:ARTIFACT_NAME.zip"
+          $archives = @(Get-ChildItem -LiteralPath $env:ARTIFACT_DIR -File -Filter '*.zip')
+          if ($archives.Count -ne 1 -or
+              $archives[0].FullName -ne $expectedPackage) {
+            throw "Expected exactly the root package $expectedPackage"
+          }
+
+          $extractDirectory = Join-Path $env:RUNNER_TEMP 'native-runtime-package'
+          New-Item -ItemType Directory -Path $extractDirectory -Force | Out-Null
+          Expand-Archive -LiteralPath $expectedPackage -DestinationPath $extractDirectory -Force
+          $binaries = @(
+            Get-ChildItem -LiteralPath $extractDirectory -Recurse -File -Filter 'floorp.exe'
+          )
+          if ($binaries.Count -ne 1) {
+            throw "Expected exactly one packaged floorp.exe; found $($binaries.Count)"
+          }
+
+          $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+          $startInfo.FileName = $binaries[0].FullName
+          $startInfo.Arguments = '--full-version'
+          $startInfo.WorkingDirectory = $binaries[0].DirectoryName
+          $startInfo.UseShellExecute = $false
+          $startInfo.RedirectStandardOutput = $true
+          $startInfo.RedirectStandardError = $true
+          $startInfo.CreateNoWindow = $true
+          [void]$startInfo.Environment.Remove('XUL_APP_FILE')
+
+          $process = [System.Diagnostics.Process]::new()
+          $process.StartInfo = $startInfo
+          try {
+            if (-not $process.Start()) {
+              throw 'Failed to start packaged floorp.exe'
+            }
+            $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+            $stderrTask = $process.StandardError.ReadToEndAsync()
+            if (-not $process.WaitForExit(30000)) {
+              $process.Kill($true)
+              $process.WaitForExit()
+              throw 'Packaged floorp.exe --full-version timed out'
+            }
+            $stdout = $stdoutTask.GetAwaiter().GetResult()
+            $stderr = $stderrTask.GetAwaiter().GetResult()
+            if ($process.ExitCode -ne 0) {
+              throw "Packaged floorp.exe exited with code $($process.ExitCode): $stderr"
+            }
+          } finally {
+            $process.Dispose()
+          }
+
+          Write-Host $stdout
+          if ($stderr) { Write-Host "stderr: $stderr" }
+          [System.IO.File]::WriteAllText(
+            $env:OUTPUT_FILE,
+            $stdout,
+            [System.Text.UTF8Encoding]::new($false)
+          )
+          & python $env:PARSER_PATH `
+            --expected-build-id $env:EXPECTED_BUILD_ID `
+            --output-file $env:OUTPUT_FILE
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Native --full-version identity parser rejected Windows output'
+          }
+
+      - name: Verify Linux final runtime natively
+        if: inputs.platform == 'Linux'
+        shell: bash
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/runtime-artifact
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          EXPECTED_BUILD_ID: ${{ inputs.expected-build-id }}
+          OUTPUT_FILE: ${{ runner.temp }}/native-full-version.txt
+          PARSER_PATH: ${{ github.workspace }}/.github/workflows/scripts/verify_full_version.py
+          TARGET_ARCH: ${{ inputs.arch }}
+        run: |
+          set -euo pipefail
+          case "$TARGET_ARCH" in
+            x86_64) expected_runner_arch=x86_64 ;;
+            aarch64) expected_runner_arch=aarch64 ;;
+            *) echo "Unsupported Linux architecture: $TARGET_ARCH" >&2; exit 1 ;;
+          esac
+          if [[ "$(uname -m)" != "$expected_runner_arch" ]]; then
+            echo "Expected native $expected_runner_arch runner, got $(uname -m)" >&2
+            exit 1
+          fi
+
+          shopt -s nullglob
+          archives=("$ARTIFACT_DIR"/*.tar.xz)
+          expected_archive="$ARTIFACT_DIR/$ARTIFACT_NAME.tar.xz"
+          if (( ${#archives[@]} != 1 )) || [[ "${archives[0]}" != "$expected_archive" ]]; then
+            echo "Expected exactly the root package $expected_archive" >&2
+            exit 1
+          fi
+
+          package_dir="$RUNNER_TEMP/native-runtime-package"
+          mkdir -p "$package_dir"
+          tar -xf "$expected_archive" -C "$package_dir"
+          mapfile -t binaries < <(find "$package_dir" -type f -name floorp -perm /111 -print)
+          if (( ${#binaries[@]} != 1 )); then
+            echo "Expected exactly one packaged floorp binary; found ${#binaries[@]}" >&2
+            exit 1
+          fi
+
+          unset XUL_APP_FILE
+          if full_version="$(timeout 30s "${binaries[0]}" --full-version 2>&1)"; then
+            :
+          else
+            status=$?
+            printf '%s\n' "$full_version" >&2
+            exit "$status"
+          fi
+          printf '%s\n' "$full_version"
+          printf '%s\n' "$full_version" > "$OUTPUT_FILE"
+          python "$PARSER_PATH" \
+            --expected-build-id "$EXPECTED_BUILD_ID" \
+            --output-file "$OUTPUT_FILE"
+
+      - name: Verify macOS universal final runtime natively
+        if: inputs.platform == 'Darwin'
+        shell: bash
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/runtime-artifact
+          EXPECTED_BUILD_ID: ${{ inputs.expected-build-id }}
+          OUTPUT_FILE: ${{ runner.temp }}/native-full-version.txt
+          PARSER_PATH: ${{ github.workspace }}/.github/workflows/scripts/verify_full_version.py
+          TARGET_ARCH: ${{ inputs.arch }}
+        run: |
+          set -euo pipefail
+          case "$TARGET_ARCH" in
+            x86_64) expected_runner_arch=x86_64; expected_slice=x86_64 ;;
+            aarch64) expected_runner_arch=arm64; expected_slice=arm64 ;;
+            *) echo "Unsupported macOS architecture: $TARGET_ARCH" >&2; exit 1 ;;
+          esac
+          if [[ "$(uname -m)" != "$expected_runner_arch" ]]; then
+            echo "Expected native $expected_runner_arch runner, got $(uname -m)" >&2
+            exit 1
+          fi
+
+          shopt -s nullglob
+          dmgs=("$ARTIFACT_DIR"/*.dmg)
+          expected_dmg="$ARTIFACT_DIR/floorp-macOS-universal-moz-artifact.dmg"
+          if (( ${#dmgs[@]} != 1 )) || [[ "${dmgs[0]}" != "$expected_dmg" ]]; then
+            echo "Expected exactly the root package $expected_dmg" >&2
+            exit 1
+          fi
+
+          mount_plist="$RUNNER_TEMP/floorp-mount.plist"
+          hdiutil attach -readonly -nobrowse -plist "$expected_dmg" > "$mount_plist"
+          mount_point="$(python - "$mount_plist" <<'PY'
+          import plistlib
+          import sys
+
+          with open(sys.argv[1], "rb") as source:
+              payload = plistlib.load(source)
+          points = [
+              entity["mount-point"]
+              for entity in payload.get("system-entities", [])
+              if isinstance(entity, dict) and entity.get("mount-point")
+          ]
+          if len(points) != 1:
+              raise SystemExit(f"expected one mounted DMG volume, found {len(points)}")
+          print(points[0])
+          PY
+          )"
+          cleanup() {
+            if [[ -n "${mount_point:-}" ]]; then
+              hdiutil detach "$mount_point" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup EXIT
+
+          app_binary="$(python - "$mount_point" <<'PY'
+          import pathlib
+          import sys
+
+          matches = [
+              path
+              for path in pathlib.Path(sys.argv[1]).glob("*.app/Contents/MacOS/floorp")
+              if path.is_file()
+          ]
+          if len(matches) != 1:
+              raise SystemExit(f"expected one packaged Floorp app, found {len(matches)}")
+          print(matches[0])
+          PY
+          )"
+          slices="$(lipo -archs "$app_binary")"
+          case " $slices " in
+            *" $expected_slice "*) ;;
+            *) echo "Universal binary lacks $expected_slice slice: $slices" >&2; exit 1 ;;
+          esac
+
+          unset XUL_APP_FILE
+          APP_BINARY="$app_binary" python3 - <<'PY'
+          import os
+          import pathlib
+          import subprocess
+          import sys
+
+          environment = os.environ.copy()
+          environment.pop("XUL_APP_FILE", None)
+          try:
+              result = subprocess.run(
+                  [os.environ["APP_BINARY"], "--full-version"],
+                  env=environment,
+                  stdout=subprocess.PIPE,
+                  stderr=subprocess.STDOUT,
+                  timeout=30,
+                  check=False,
+              )
+          except subprocess.TimeoutExpired as error:
+              if error.stdout:
+                  sys.stderr.buffer.write(error.stdout)
+              raise SystemExit(
+                  "packaged Floorp --full-version timed out after 30 seconds"
+              ) from error
+
+          if result.returncode != 0:
+              sys.stderr.buffer.write(result.stdout)
+              raise SystemExit(
+                  f"packaged Floorp exited with code {result.returncode}"
+              )
+          sys.stdout.buffer.write(result.stdout)
+          pathlib.Path(os.environ["OUTPUT_FILE"]).write_bytes(result.stdout)
+          PY
+          python "$PARSER_PATH" \
+            --expected-build-id "$EXPECTED_BUILD_ID" \
+            --output-file "$OUTPUT_FILE"

--- a/.github/workflows/wrapper-build-linux.yml
+++ b/.github/workflows/wrapper-build-linux.yml
@@ -3,6 +3,10 @@
 
 name: Linux Build
 
+permissions:
+  actions: read
+  contents: read
+
 'on':
   workflow_dispatch:
     inputs:
@@ -23,6 +27,11 @@ name: Linux Build
           - aarch64
         default: x86_64
         required: true
+      requested_MOZ_BUILD_DATE:
+        description: 'Optional 14-digit build ID assertion'
+        type: string
+        default: ''
+        required: false
 
   workflow_call:
     inputs:
@@ -33,36 +42,77 @@ name: Linux Build
       pgo:
         description: 'Enable Profile-Guided Optimization'
         type: boolean
-        default: false
         required: true
       arch:
         description: 'Target architecture'
         type: string
         default: x86_64
         required: false
+      MOZ_BUILD_DATE:
+        description: 'Resolved 14-digit build ID'
+        type: string
+        required: true
+    outputs:
+      artifact-name:
+        description: 'Primary final build artifact name'
+        value: >-
+          ${{ inputs.pgo && inputs.arch != 'aarch64' &&
+          jobs.build-pgo-final.outputs.artifact-name ||
+          jobs.build-normal.outputs.artifact-name }}
+      artifact-id:
+        description: 'Primary final build artifact ID'
+        value: >-
+          ${{ inputs.pgo && inputs.arch != 'aarch64' &&
+          jobs.build-pgo-final.outputs.artifact-id ||
+          jobs.build-normal.outputs.artifact-id }}
+      artifact-digest:
+        description: 'Primary final build artifact digest'
+        value: >-
+          ${{ inputs.pgo && inputs.arch != 'aarch64' &&
+          jobs.build-pgo-final.outputs.artifact-digest ||
+          jobs.build-normal.outputs.artifact-digest }}
+      expected-build-id:
+        description: 'Build ID embedded in the primary final artifact'
+        value: >-
+          ${{ inputs.pgo && inputs.arch != 'aarch64' &&
+          jobs.build-pgo-final.outputs.expected-build-id ||
+          jobs.build-normal.outputs.expected-build-id }}
 
 run-name: >-
-  ${{ inputs.pgo && '[PGO] ' || '' }}Linux ${{ inputs.arch || 'x64' }}
+  ${{ inputs.pgo && inputs.arch != 'aarch64' && '[PGO] ' || '' }}Linux
+  ${{ inputs.arch || 'x86_64' }}
   ${{ inputs.debug && ' Debug' || '' }}
 
 jobs:
+  resolve-build-context:
+    uses: ./.github/workflows/resolve-build-context.yml
+    with:
+      resolved_moz_build_date: ${{ inputs.MOZ_BUILD_DATE || '' }}
+      requested_moz_build_date: >-
+        ${{ inputs.requested_MOZ_BUILD_DATE || '' }}
+      require_run_metadata: false
+
   build-normal:
     name: >-
       Linux ${{ inputs.arch || 'x86_64' }}
       ${{ inputs.debug && ' Debug' || '' }}
     if: ${{ !inputs.pgo || inputs.arch == 'aarch64' }}
+    needs: resolve-build-context
     uses: ./.github/workflows/common-build.yml
     with:
       platform: linux
       arch: ${{ inputs.arch || 'x86_64' }}
       debug: ${{ inputs.debug }}
       pgo: false
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   build-pgo-stage1:
     name: >-
       Linux ${{ inputs.arch || 'x86_64' }} PGO Stage 1
       ${{ inputs.debug && ' Debug' || '' }}
     if: ${{ inputs.pgo && inputs.arch != 'aarch64' }}
+    needs: resolve-build-context
     uses: ./.github/workflows/common-build.yml
     with:
       platform: linux
@@ -70,28 +120,32 @@ jobs:
       debug: ${{ inputs.debug }}
       pgo: true
       pgo_mode: 'generate'
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   collect-profiles:
     name: Linux ${{ inputs.arch || 'x86_64' }} PGO Stage 2
     if: ${{ inputs.pgo && inputs.arch != 'aarch64' }}
-    needs: build-pgo-stage1
+    needs: [resolve-build-context, build-pgo-stage1]
     uses: ./.github/workflows/generate-pgo-profile-linux.yml
     secrets: inherit
     with:
       browser-artifact-name: >-
-        floorp-linux-${{ inputs.arch || 'x86_64' }}-moz-artifact
+        floorp-linux-x86_64-profile-generate-mode-package
       artifact-path: /home/runner/artifact
       runner: ubuntu-latest
       target-arch: ${{ inputs.arch || 'x86_64' }}
       upload-artifact-name: >-
         floorp-linux-${{ inputs.arch || 'x86_64' }}-profile-generate-output
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   build-pgo-final:
     name: >-
       Linux ${{ inputs.arch || 'x86_64' }} PGO Stage 3
       ${{ inputs.debug && ' Debug' || '' }}
     if: ${{ inputs.pgo && inputs.arch != 'aarch64' }}
-    needs: collect-profiles
+    needs: [resolve-build-context, collect-profiles]
     uses: ./.github/workflows/common-build.yml
     with:
       platform: linux
@@ -101,3 +155,5 @@ jobs:
       pgo_mode: 'use'
       pgo_artifact_name: >-
         floorp-linux-${{ inputs.arch || 'x86_64' }}-profile-generate-output
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}

--- a/.github/workflows/wrapper-build-windows.yml
+++ b/.github/workflows/wrapper-build-windows.yml
@@ -15,6 +15,13 @@ name: Windows Build
         type: boolean
         default: false
         required: true
+      requested_MOZ_BUILD_DATE:
+        description: >-
+          Optional build ID to assert (14 UTC digits); defaults to this run's
+          trusted GitHub Actions creation time
+        type: string
+        required: false
+        default: ''
 
   workflow_call:
     inputs:
@@ -25,28 +32,68 @@ name: Windows Build
       pgo:
         description: 'Enable Profile-Guided Optimization'
         type: boolean
-        default: false
         required: true
+      MOZ_BUILD_DATE:
+        description: 'Trusted resolved build ID (14 UTC digits)'
+        type: string
+        required: true
+    outputs:
+      artifact-name:
+        description: 'Final primary Windows artifact name'
+        value: >-
+          ${{ jobs.build-normal.outputs.artifact-name ||
+          jobs.build-pgo-final.outputs.artifact-name }}
+      artifact-id:
+        description: 'Final primary Windows artifact ID'
+        value: >-
+          ${{ jobs.build-normal.outputs.artifact-id ||
+          jobs.build-pgo-final.outputs.artifact-id }}
+      artifact-digest:
+        description: 'Final primary Windows artifact digest'
+        value: >-
+          ${{ jobs.build-normal.outputs.artifact-digest ||
+          jobs.build-pgo-final.outputs.artifact-digest }}
+      expected-build-id:
+        description: 'Expected build ID embedded in the final artifact'
+        value: >-
+          ${{ jobs.build-normal.outputs.expected-build-id ||
+          jobs.build-pgo-final.outputs.expected-build-id }}
+
+permissions:
+  actions: read
+  contents: read
 
 run-name: >-
   ${{ inputs.pgo && '[PGO] ' || '' }}Windows x64
   ${{ inputs.debug && ' Debug' || '' }}
 
 jobs:
+  resolve-build-context:
+    uses: ./.github/workflows/resolve-build-context.yml
+    with:
+      resolved_moz_build_date: ${{ inputs.MOZ_BUILD_DATE || '' }}
+      requested_moz_build_date: >-
+        ${{ inputs.requested_MOZ_BUILD_DATE || '' }}
+      require_run_metadata: false
+
   build-normal:
     name: Windows x64${{ inputs.debug && ' Debug' || '' }}
     if: ${{ !inputs.pgo }}
+    needs: resolve-build-context
     uses: ./.github/workflows/common-build.yml
     with:
       platform: windows
       arch: x86_64
       debug: ${{ inputs.debug }}
       pgo: false
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   build-pgo-stage1:
     name: >-
       Windows x64 PGO Stage 1${{ inputs.debug && ' Debug' || '' }}
     if: ${{ inputs.pgo }}
+    needs: resolve-build-context
     uses: ./.github/workflows/common-build.yml
     with:
       platform: windows
@@ -54,14 +101,18 @@ jobs:
       debug: ${{ inputs.debug }}
       pgo: true
       pgo_mode: 'generate'
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   collect-profiles:
     name: Windows x64 PGO Stage 2
     if: ${{ inputs.pgo }}
-    needs: build-pgo-stage1
+    needs: [resolve-build-context, build-pgo-stage1]
     uses: ./.github/workflows/generate-pgo-profile-windows.yml
     secrets: inherit
     with:
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}
       browser-artifact-name: >-
         floorp-windows-x86_64-profile-generate-mode-package
       artifact-path: C:\artifact
@@ -74,7 +125,7 @@ jobs:
     name: >-
       Windows x64 PGO Stage 3${{ inputs.debug && ' Debug' || '' }}
     if: ${{ inputs.pgo }}
-    needs: collect-profiles
+    needs: [resolve-build-context, collect-profiles]
     uses: ./.github/workflows/common-build.yml
     with:
       platform: windows
@@ -84,3 +135,5 @@ jobs:
       pgo_mode: 'use'
       pgo_artifact_name: >-
         floorp-windows-x86_64-profile-generate-output
+      MOZ_BUILD_DATE: >-
+        ${{ needs.resolve-build-context.outputs.expected-build-id }}

--- a/.github/workflows/wrapper-mac-build.yml
+++ b/.github/workflows/wrapper-mac-build.yml
@@ -13,6 +13,11 @@ on:
       pgo:
         type: boolean
         required: true
+      requested_MOZ_BUILD_DATE:
+        description: "Optional 14-digit build ID assertion"
+        type: string
+        required: false
+        default: ""
 
   workflow_call:
     inputs:
@@ -22,19 +27,37 @@ on:
       pgo:
         type: boolean
         required: true
+      MOZ_BUILD_DATE:
+        description: "Trusted resolved 14-digit build ID"
+        type: string
+        required: true
+    outputs:
+      artifact-name:
+        description: "Final universal macOS artifact name"
+        value: ${{ jobs.part2_no_pgo.outputs.artifact-name || jobs.part4_pgo.outputs.artifact-name }}
+      artifact-id:
+        description: "Final universal macOS artifact ID"
+        value: ${{ jobs.part2_no_pgo.outputs.artifact-id || jobs.part4_pgo.outputs.artifact-id }}
+      artifact-digest:
+        description: "Final universal macOS artifact digest"
+        value: ${{ jobs.part2_no_pgo.outputs.artifact-digest || jobs.part4_pgo.outputs.artifact-digest }}
+      expected-build-id:
+        description: "Expected build ID embedded in the final artifact"
+        value: ${{ jobs.part2_no_pgo.outputs.expected-build-id || jobs.part4_pgo.outputs.expected-build-id }}
+
+permissions:
+  actions: read
+  contents: read
 
 run-name: ${{toJSON(inputs.pgo) == 'true' && '[PGO] ' || ''}}Mac x64 build${{toJSON(inputs.debug) == 'true' && ' Debug' || ''}}
 jobs:
-  get-buildid:
-    runs-on: ubuntu-latest
-    outputs:
-      buildids: ${{ steps.get.outputs.bid }}
-    steps:
-      - id: get
-        shell: bash -xe {0}
-        run: |
-          bdat=`date +"%Y%m%d%I%M%S"`
-          echo "bid=${bdat}" >> $GITHUB_OUTPUT
+  resolve-build-context:
+    uses: ./.github/workflows/resolve-build-context.yml
+    with:
+      resolved_moz_build_date: ${{ inputs.MOZ_BUILD_DATE || '' }}
+      requested_moz_build_date: >-
+        ${{ inputs.requested_MOZ_BUILD_DATE || '' }}
+      require_run_metadata: false
 
   download-macos-sdk:
     runs-on: macos-26
@@ -91,10 +114,11 @@ jobs:
           name: macos-sdk
           path: macos_sdk.tar.gz
           retention-days: 1
+          if-no-files-found: error
           overwrite: true
 
   part1-x86_64:
-    needs: [get-buildid, download-macos-sdk]
+    needs: [resolve-build-context, download-macos-sdk]
     uses: ./.github/workflows/common-build.yml
     with:
       platform: mac
@@ -102,10 +126,10 @@ jobs:
       debug: ${{ inputs.debug }}
       pgo: ${{ inputs.pgo }}
       pgo_mode: ${{ inputs.pgo && 'generate' || '' }}
-      MOZ_BUILD_DATE: ${{ needs.get-buildid.outputs.buildids }}
+      MOZ_BUILD_DATE: ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   part1-aarch64:
-    needs: [get-buildid, download-macos-sdk]
+    needs: [resolve-build-context, download-macos-sdk]
     uses: ./.github/workflows/common-build.yml
     with:
       platform: mac
@@ -113,15 +137,17 @@ jobs:
       debug: ${{ inputs.debug }}
       pgo: ${{ inputs.pgo }}
       pgo_mode: ${{ inputs.pgo && 'generate' || '' }}
-      MOZ_BUILD_DATE: ${{ needs.get-buildid.outputs.buildids }}
+      MOZ_BUILD_DATE: ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   part2:
-    needs: [get-buildid, part1-x86_64, part1-aarch64]
+    needs: [resolve-build-context, part1-x86_64, part1-aarch64]
     if: ${{ inputs.pgo }}
     uses: ./.github/workflows/mac_pgo.yml
+    with:
+      MOZ_BUILD_DATE: ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   part3-x86_64:
-    needs: [get-buildid, part2]
+    needs: [resolve-build-context, part2]
     if: ${{ inputs.pgo }}
     uses: ./.github/workflows/common-build.yml
     with:
@@ -131,10 +157,10 @@ jobs:
       pgo: ${{ inputs.pgo }}
       pgo_mode: use
       pgo_artifact_name: floorp-x86_64-apple-darwin-profdata-and-jarlog
-      MOZ_BUILD_DATE: ${{ needs.get-buildid.outputs.buildids }}
+      MOZ_BUILD_DATE: ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   part3-aarch64:
-    needs: [get-buildid, part2]
+    needs: [resolve-build-context, part2]
     if: ${{ inputs.pgo }}
     uses: ./.github/workflows/common-build.yml
     with:
@@ -144,28 +170,28 @@ jobs:
       pgo: ${{ inputs.pgo }}
       pgo_mode: use
       pgo_artifact_name: floorp-aarch64-apple-darwin-profdata-and-jarlog
-      MOZ_BUILD_DATE: ${{ needs.get-buildid.outputs.buildids }}
+      MOZ_BUILD_DATE: ${{ needs.resolve-build-context.outputs.expected-build-id }}
 
   part2_no_pgo:
     name: "Integration (No PGO)"
-    needs: [get-buildid, part1-x86_64, part1-aarch64]
+    needs: [resolve-build-context, part1-x86_64, part1-aarch64]
     if: ${{ !inputs.pgo }}
     uses: ./.github/workflows/mac_integration.yml
     secrets: inherit
     with:
       x86_64_artifact_name: floorp-mac-x86_64-moz-artifact
       aarch64_artifact_name: floorp-mac-aarch64-moz-artifact
-      MOZ_BUILD_DATE: ${{ needs.get-buildid.outputs.buildids }}
+      MOZ_BUILD_DATE: ${{ needs.resolve-build-context.outputs.expected-build-id }}
       debug: ${{ inputs.debug }}
 
   part4_pgo:
     name: "Integration (With PGO)"
-    needs: [get-buildid, part3-x86_64, part3-aarch64]
+    needs: [resolve-build-context, part3-x86_64, part3-aarch64]
     if: ${{ inputs.pgo }}
     uses: ./.github/workflows/mac_integration.yml
     secrets: inherit
     with:
       x86_64_artifact_name: floorp-mac-x86_64-moz-artifact
       aarch64_artifact_name: floorp-mac-aarch64-moz-artifact
-      MOZ_BUILD_DATE: ${{ needs.get-buildid.outputs.buildids }}
+      MOZ_BUILD_DATE: ${{ needs.resolve-build-context.outputs.expected-build-id }}
       debug: ${{ inputs.debug }}


### PR DESCRIPTION
## Summary

- derive one deterministic `MOZ_BUILD_DATE` from the immutable Actions run `created_at`
- propagate the same build identity through normal and PGO Windows/Linux/macOS builds
- upload consolidated primary artifacts with immutable ID/digest outputs and aggregate a schema-v2 Runtime manifest
- gate aggregation and publication on native `--full-version` checks for Windows x64, Linux x64/arm64, and both macOS universal slices
- add a side-effect-free `validation_only` dispatch path for real CI verification
- add updater XML persistence coverage for `appVersion2` and `buildID2`

This is the Runtime portion of the permanent fix for Floorp-Projects/Floorp#2584. It does not change the live update endpoint or publish a release.

## Verification

Local/static checks:

- resolver/static tests: 24 passed
- native verifier tests: 10 passed
- actionlint v1.7.12: all 11 changed/new workflows passed
- Python compile, Prettier 3.8.1, bash syntax, patch applicability, and diff checks passed
- independent Tier-1 review found no code-level P0/P1 issue

Real GitHub Actions proof:

- validation run: https://github.com/Floorp-Projects/Floorp-Runtime/actions/runs/30016595833
- exact head: `c47d139bafff7aa132d6ad3db0022bba85b92309`
- result: success (`validation_only=true`, `debug=false`, `pgo=false`)
- deterministic BuildID: `20260723143615`, derived from run `created_at=2026-07-23T14:36:15Z`
- native verification: 5/5 passed (Windows x64, Linux x64/arm64, macOS x64/arm64)
- aggregate manifest artifact: `floorp-runtime-build-manifest-v2`, ID `8572748299`
- artifact digest: `sha256:0ca80bfa8dad9d7035e2d91c7d30c82018037f34b3c3c338e821ac159e5745d3`
- Android, FTP, and release publication paths were skipped as designed

The run above is branch-level validation proof only. It is not eligible as a production input because production requires a Runtime run from the default branch `nora-0.2.0`.

Production rollout requires merging this PR first, then running the workflow again from `nora-0.2.0` and passing the new exact run ID plus manifest artifact ID to Floorp. A mutable branch artifact must never be used.