### PR TITLE
fix(ci): validate mac PGO Stage 1 bundles

### DIFF
--- a/.github/workflows/mac_pgo.yml
+++ b/.github/workflows/mac_pgo.yml
@@ -145,56 +145,17 @@ jobs:
           echo "Extraction complete. Checking workspace:"
           ls -la ${{ github.workspace }}/obj-${ARCH_TYPE}-apple-darwin/ || echo "Directory not found"
 
-      - name: Verify Stage 1 runtime build identity
+      - name: Verify Stage 1 profile bundle identity
+        id: verify_stage1
         shell: bash
-        env:
-          EXPECTED_RUNNER_ARCH: ${{ matrix.runner-arch }}
         run: |
           set -euo pipefail
-
-          if [[ ! "$MOZ_BUILD_DATE" =~ ^[0-9]{14}$ ]]; then
-            echo "Expected build ID must be exactly 14 digits: $MOZ_BUILD_DATE" >&2
-            exit 1
-          fi
-
-          RUNNER_ARCH=$(uname -m)
-          if [[ "$RUNNER_ARCH" != "$EXPECTED_RUNNER_ARCH" ]]; then
-            echo "Runner architecture $RUNNER_ARCH does not match $EXPECTED_RUNNER_ARCH for $ARCH_TYPE" >&2
-            exit 1
-          fi
-
-          APP_BINARY=$(find \
-            "./obj-${ARCH_TYPE}-apple-darwin/dist/floorp" \
-            -type f -path "*.app/Contents/MacOS/floorp" -print | sed -n '1p')
-          if [[ -z "$APP_BINARY" || ! -x "$APP_BINARY" ]]; then
-            echo "Unable to locate an executable Stage 1 Floorp app for $ARCH_TYPE" >&2
-            exit 1
-          fi
-
-          unset XUL_APP_FILE
-          echo "Running native identity check: $APP_BINARY --full-version"
-          FULL_VERSION_OUTPUT=$("$APP_BINARY" --full-version 2>&1)
-          printf '%s\n' "$FULL_VERSION_OUTPUT"
-
-          BUILD_IDS=$(printf '%s\n' "$FULL_VERSION_OUTPUT" | grep -Eo '[0-9]{14}' || true)
-          BUILD_ID_COUNT=$(printf '%s\n' "$BUILD_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
-          FIRST_BUILD_ID=$(printf '%s\n' "$BUILD_IDS" | sed -n '1p')
-          SECOND_BUILD_ID=$(printf '%s\n' "$BUILD_IDS" | sed -n '2p')
-
-          if [[ "$BUILD_ID_COUNT" != "2" ]]; then
-            echo "Expected exactly two 14-digit IDs from --full-version, found $BUILD_ID_COUNT" >&2
-            exit 1
-          fi
-          if [[ "$FIRST_BUILD_ID" != "$MOZ_BUILD_DATE" || "$SECOND_BUILD_ID" != "$MOZ_BUILD_DATE" ]]; then
-            echo "Stage 1 IDs do not both match expected build ID $MOZ_BUILD_DATE" >&2
-            exit 1
-          fi
-          if ! printf '%s\n' "$FULL_VERSION_OUTPUT" | grep -Eq "(^|[^0-9])${MOZ_BUILD_DATE}[[:space:]]+${MOZ_BUILD_DATE}([^0-9]|$)"; then
-            echo "The two expected build IDs are not adjacent in --full-version output" >&2
-            exit 1
-          fi
-
-          echo "STAGE1_APP_BINARY=$APP_BINARY" >> "$GITHUB_ENV"
+          python3 .github/workflows/scripts/verify_mac_pgo_stage1.py \
+            --workspace-root "$GITHUB_WORKSPACE" \
+            --search-root "./obj-${ARCH_TYPE}-apple-darwin/dist/floorp" \
+            --expected-build-id "$MOZ_BUILD_DATE" \
+            --expected-arch "${{ matrix.runner-arch }}" \
+            --github-output "$GITHUB_OUTPUT"
 
 ## ./mach python python/mozbuild/mozbuild/action/install.py $MOZ_FETCHES_DIR/target.dmg $MOZ_FETCHES_DIR
       - name: Generate Profdata 📊
@@ -203,6 +164,7 @@ jobs:
           MACOS_SDK_DIR: ${{ env.RUNNER_USERDIR }}/macos-sdk
           MOZ_SDK_DIR: ${{ env.RUNNER_USERDIR }}/macos-sdk
           GHA_BUILD_MACHINE: ${{ matrix.runs-on }}
+          STAGE1_APP_BINARY: ${{ steps.verify_stage1.outputs.app_binary }}
         run: |
           # Use LLVM 19's llvm-profdata
           if [[ -f /opt/homebrew/opt/llvm@19/bin/llvm-profdata ]]; then
@@ -218,6 +180,19 @@ jobs:
           
           export JARLOG_FILE="en-US.log"
           ./mach python build/pgo/profileserver.py --binary "$STAGE1_APP_BINARY"
+
+          for output in merged.profdata en-US.log; do
+            if ! test -e "$output"; then
+              echo "Required profile output is missing: $output" >&2
+              exit 1
+            fi
+            if ! test -s "$output"; then
+              echo "Required profile output is empty: $output" >&2
+              exit 1
+            fi
+            bytes=$(wc -c < "$output" | tr -d '[:space:]')
+            echo "$output byte_size=$bytes"
+          done
 
       - name: Publish 🎁
         uses: actions/upload-artifact@v4

--- a/.github/workflows/scripts/test_verify_mac_pgo_stage1.py
+++ b/.github/workflows/scripts/test_verify_mac_pgo_stage1.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import verify_mac_pgo_stage1 as verifier
+
+EXPECTED = "20260724044918"
+
+
+class Stage1VerifierTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name) / "stage 1 root"
+        self.binary = self._create_app(self.root, "Floorp.app")
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def _create_app(self, root: Path, name: str) -> Path:
+        binary = root / name / "Contents" / "MacOS" / "floorp"
+        resources = root / name / "Contents" / "Resources"
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        resources.mkdir(parents=True, exist_ok=True)
+        binary.write_bytes(b"stage1")
+        (resources / "application.ini").write_text(
+            f"[App]\nBuildID={EXPECTED}\nName=%PRODUCT%\n",
+            encoding="utf-8",
+        )
+        (resources / "platform.ini").write_text(
+            f"[Build]\nBuildID={EXPECTED}\n",
+            encoding="utf-8",
+        )
+        return binary
+
+    def _lipo(
+        self,
+        stdout: str = "x86_64\n",
+        *,
+        returncode: int = 0,
+        stderr: str = "",
+    ):
+        def run(command, **kwargs):
+            self.assertEqual(command[:2], [verifier.LIPO, "-archs"])
+            self.assertFalse(kwargs.get("check"))
+            self.assertTrue(kwargs.get("capture_output"))
+            return subprocess.CompletedProcess(
+                command,
+                returncode,
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        return run
+
+    def _verify(self, arch: str = "x86_64") -> verifier.Stage1Identity:
+        return verifier.verify_stage1(
+            self.root.parent,
+            self.root,
+            EXPECTED,
+            arch,
+            machine=arch,
+            lipo_runner=self._lipo(f"{arch}\n"),
+            executable_check=lambda _path, mode: mode == os.X_OK,
+        )
+
+    def test_accepts_x86_64_bundle_with_space_in_path(self) -> None:
+        identity = self._verify()
+        self.assertEqual(identity.binary, self.binary.resolve())
+        self.assertEqual(identity.application_build_id, EXPECTED)
+        self.assertEqual(identity.platform_build_id, EXPECTED)
+
+    def test_accepts_arm64_runner_and_thin_slice(self) -> None:
+        identity = self._verify("arm64")
+        self.assertEqual(identity.runner_arch, "arm64")
+        self.assertEqual(identity.binary_arch, "arm64")
+
+    def test_rejects_invalid_expected_build_id(self) -> None:
+        for build_id in ("", "20260230010203", "２０２６０７２４０４４９１８"):
+            with self.subTest(build_id=build_id), self.assertRaises(
+                verifier.Stage1VerificationError
+            ):
+                verifier.verify_stage1(
+                    self.root.parent,
+                    self.root,
+                    build_id,
+                    "x86_64",
+                    machine="x86_64",
+                    lipo_runner=self._lipo(),
+                    executable_check=lambda _path, _mode: True,
+                )
+
+    def test_rejects_missing_or_multiple_direct_child_apps(self) -> None:
+        self.binary.unlink()
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "found 0"):
+            self._verify()
+
+        self.binary = self._create_app(self.root, "Floorp.app")
+        self._create_app(self.root, "Other.app")
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "found 2"):
+            self._verify()
+
+    def test_ignores_nested_app(self) -> None:
+        self._create_app(self.root / "nested", "Nested.app")
+        self.assertEqual(self._verify().binary, self.binary.resolve())
+
+    def test_rejects_non_executable_binary(self) -> None:
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "not executable"):
+            verifier.verify_stage1(
+                self.root.parent,
+                self.root,
+                EXPECTED,
+                "x86_64",
+                machine="x86_64",
+                lipo_runner=self._lipo(),
+                executable_check=lambda _path, _mode: False,
+            )
+
+    def test_rejects_path_outside_root(self) -> None:
+        outside = self.root.parent / "outside" / "floorp"
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "escapes"):
+            verifier.require_within_root(self.root.resolve(), outside.resolve())
+
+    def test_rejects_symlink_escape_when_supported(self) -> None:
+        outside = self.root.parent / "outside-floorp"
+        outside.write_bytes(b"outside")
+        self.binary.unlink()
+        try:
+            self.binary.symlink_to(outside)
+        except OSError as exc:
+            self.skipTest(f"symlinks unavailable: {exc}")
+        with self.assertRaisesRegex(
+            verifier.Stage1VerificationError, "escapes|symlinks"
+        ):
+            self._verify()
+
+    def test_rejects_symlinked_search_root_when_supported(self) -> None:
+        linked_root = self.root.parent / "linked-root"
+        try:
+            linked_root.symlink_to(self.root, target_is_directory=True)
+        except OSError as exc:
+            self.skipTest(f"symlinks unavailable: {exc}")
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "symlinks"):
+            verifier.verify_stage1(
+                self.root.parent,
+                linked_root,
+                EXPECTED,
+                "x86_64",
+                machine="x86_64",
+                lipo_runner=self._lipo(),
+                executable_check=lambda _path, _mode: True,
+            )
+
+    def test_rejects_symlinked_resource_file_when_supported(self) -> None:
+        application_ini = self.binary.parent.parent / "Resources" / "application.ini"
+        outside = self.root.parent / "outside-application.ini"
+        outside.write_text(f"[App]\nBuildID={EXPECTED}\n", encoding="utf-8")
+        application_ini.unlink()
+        try:
+            application_ini.symlink_to(outside)
+        except OSError as exc:
+            self.skipTest(f"symlinks unavailable: {exc}")
+        with self.assertRaisesRegex(
+            verifier.Stage1VerificationError, "escapes|symlinks"
+        ):
+            self._verify()
+
+    def test_rejects_non_regular_resource_file(self) -> None:
+        platform_ini = self.binary.parent.parent / "Resources" / "platform.ini"
+        platform_ini.unlink()
+        platform_ini.mkdir()
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "not a regular"):
+            self._verify()
+
+    def test_rejects_wrong_or_unsupported_runner_arch(self) -> None:
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "runner"):
+            verifier.verify_stage1(
+                self.root.parent,
+                self.root,
+                EXPECTED,
+                "x86_64",
+                machine="arm64",
+                lipo_runner=self._lipo(),
+                executable_check=lambda _path, _mode: True,
+            )
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "unsupported"):
+            verifier.verify_stage1(
+                self.root.parent,
+                self.root,
+                EXPECTED,
+                "aarch64",
+                machine="aarch64",
+                lipo_runner=self._lipo("aarch64\n"),
+                executable_check=lambda _path, _mode: True,
+            )
+
+    def test_rejects_lipo_failure_wrong_slice_and_multiple_slices(self) -> None:
+        cases = (
+            (self._lipo(returncode=1, stderr="invalid"), "exit code"),
+            (self._lipo("arm64\n"), "mismatch"),
+            (self._lipo("x86_64 arm64\n"), "exactly one"),
+            (self._lipo(""), "exactly one"),
+        )
+        for lipo_runner, message in cases:
+            with self.subTest(message=message), self.assertRaisesRegex(
+                verifier.Stage1VerificationError, message
+            ):
+                verifier.verify_stage1(
+                    self.root.parent,
+                    self.root,
+                    EXPECTED,
+                    "x86_64",
+                    machine="x86_64",
+                    lipo_runner=lipo_runner,
+                    executable_check=lambda _path, _mode: True,
+                )
+
+    def test_rejects_missing_lipo_program(self) -> None:
+        def missing_lipo(_command, **_kwargs):
+            raise FileNotFoundError(verifier.LIPO)
+
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "inspect"):
+            verifier.verify_stage1(
+                self.root.parent,
+                self.root,
+                EXPECTED,
+                "x86_64",
+                machine="x86_64",
+                lipo_runner=missing_lipo,
+                executable_check=lambda _path, _mode: True,
+            )
+
+    def test_rejects_missing_or_malformed_ini(self) -> None:
+        application_ini = self.binary.parent.parent / "Resources" / "application.ini"
+        application_ini.unlink()
+        with self.assertRaisesRegex(
+            verifier.Stage1VerificationError, "could not resolve"
+        ):
+            self._verify()
+
+        application_ini.write_text("not-an-ini\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+            verifier.Stage1VerificationError, "could not parse"
+        ):
+            self._verify()
+
+    def test_rejects_duplicate_section_or_option(self) -> None:
+        application_ini = self.binary.parent.parent / "Resources" / "application.ini"
+        for contents in (
+            f"[App]\nBuildID={EXPECTED}\n[App]\nName=Floorp\n",
+            f"[App]\nBuildID={EXPECTED}\nBuildID={EXPECTED}\n",
+        ):
+            application_ini.write_text(contents, encoding="utf-8")
+            with self.subTest(contents=contents), self.assertRaisesRegex(
+                verifier.Stage1VerificationError, "could not parse"
+            ):
+                self._verify()
+
+    def test_rejects_missing_or_mismatched_ini_build_id(self) -> None:
+        resources = self.binary.parent.parent / "Resources"
+        application_ini = resources / "application.ini"
+        platform_ini = resources / "platform.ini"
+
+        application_ini.write_text("[App]\nName=Floorp\n", encoding="utf-8")
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "missing"):
+            self._verify()
+
+        application_ini.write_text(f"[App]\nBuildID={EXPECTED}\n", encoding="utf-8")
+        platform_ini.write_text("[Build]\nBuildID=20260724044919\n", encoding="utf-8")
+        with self.assertRaisesRegex(verifier.Stage1VerificationError, "mismatch"):
+            self._verify()
+
+    def test_writes_exact_output_and_rejects_line_breaks(self) -> None:
+        output = Path(self.temporary_directory.name) / "github-output"
+        verifier.write_github_output(
+            output,
+            "app_binary",
+            str(self.binary.resolve()),
+        )
+        self.assertEqual(
+            output.read_text(encoding="utf-8"),
+            f"app_binary={self.binary.resolve()}\n",
+        )
+        for value in ("bad\npath", "bad\rpath"):
+            with self.subTest(value=value), self.assertRaisesRegex(
+                verifier.Stage1VerificationError, "line break"
+            ):
+                verifier.write_github_output(output, "app_binary", value)
+
+    def test_workflow_preserves_proof_chain(self) -> None:
+        workflow = (Path(__file__).resolve().parents[1] / "mac_pgo.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("id: verify_stage1", workflow)
+        self.assertIn("verify_mac_pgo_stage1.py", workflow)
+        self.assertIn('--workspace-root "$GITHUB_WORKSPACE"', workflow)
+        self.assertIn('--expected-arch "${{ matrix.runner-arch }}"', workflow)
+        self.assertIn('--github-output "$GITHUB_OUTPUT"', workflow)
+        self.assertNotIn("--full-version", workflow)
+        self.assertIn(
+            "STAGE1_APP_BINARY: ${{ steps.verify_stage1.outputs.app_binary }}",
+            workflow,
+        )
+        self.assertIn('profileserver.py --binary "$STAGE1_APP_BINARY"', workflow)
+        self.assertIn('if ! test -s "$output"', workflow)
+        self.assertIn('echo "$output byte_size=$bytes"', workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/scripts/verify_mac_pgo_stage1.py
+++ b/.github/workflows/scripts/verify_mac_pgo_stage1.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import os
+import platform
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable
+
+BUILD_ID_RE = re.compile(r"[0-9]{14}", re.ASCII)
+SUPPORTED_ARCHES = frozenset({"arm64", "x86_64"})
+LIPO = "/usr/bin/lipo"
+
+
+class Stage1VerificationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Stage1Identity:
+    binary: Path
+    runner_arch: str
+    binary_arch: str
+    application_build_id: str
+    platform_build_id: str
+
+
+def validate_build_id(value: str) -> str:
+    if not isinstance(value, str) or BUILD_ID_RE.fullmatch(value) is None:
+        raise Stage1VerificationError("build ID must be exactly 14 ASCII digits")
+    try:
+        parsed = datetime.strptime(value, "%Y%m%d%H%M%S")
+    except ValueError as exc:
+        raise Stage1VerificationError("build ID must be a valid UTC timestamp") from exc
+    if parsed.strftime("%Y%m%d%H%M%S") != value:
+        raise Stage1VerificationError("build ID must be canonical")
+    return value
+
+
+def require_within_root(root: Path, path: Path, label: str = "path") -> None:
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise Stage1VerificationError(f"{label} escapes trusted root: {path}") from exc
+
+
+def resolve_search_root(workspace_root: Path, search_root: Path) -> Path:
+    try:
+        workspace = workspace_root.resolve(strict=True)
+    except OSError as exc:
+        raise Stage1VerificationError(
+            f"could not resolve workspace root {workspace_root}: {exc}"
+        ) from exc
+    if not workspace.is_dir():
+        raise Stage1VerificationError(f"workspace root is not a directory: {workspace}")
+
+    declared = search_root if search_root.is_absolute() else workspace / search_root
+    declared = Path(os.path.abspath(declared))
+    require_within_root(workspace, declared, "Stage 1 search root")
+    current = workspace
+    for component in declared.relative_to(workspace).parts:
+        current /= component
+        if current.is_symlink():
+            raise Stage1VerificationError(
+                f"Stage 1 search root must not contain symlinks: {current}"
+            )
+    try:
+        root = declared.resolve(strict=True)
+    except OSError as exc:
+        raise Stage1VerificationError(
+            f"could not resolve Stage 1 search root {declared}: {exc}"
+        ) from exc
+    if root != declared:
+        raise Stage1VerificationError(
+            f"Stage 1 search root must not contain symlinks: {declared}"
+        )
+    if not root.is_dir():
+        raise Stage1VerificationError(f"Stage 1 search root is not a directory: {root}")
+    return root
+
+
+def discover_binary(
+    workspace_root: Path,
+    search_root: Path,
+    executable_check: Callable[[Path, int], bool] | None = None,
+) -> tuple[Path, Path]:
+    root = resolve_search_root(workspace_root, search_root)
+
+    candidates = sorted(root.glob("*.app/Contents/MacOS/floorp"))
+    if len(candidates) != 1:
+        raise Stage1VerificationError(
+            f"expected exactly one Stage 1 app binary in {root}, "
+            f"found {len(candidates)}"
+        )
+
+    candidate = candidates[0]
+    try:
+        binary = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise Stage1VerificationError(
+            f"could not resolve Stage 1 binary {candidate}: {exc}"
+        ) from exc
+    require_within_root(root, binary, "Stage 1 binary")
+    if binary != candidate:
+        raise Stage1VerificationError(
+            f"Stage 1 binary path must not contain symlinks: {candidate}"
+        )
+    if not binary.is_file():
+        raise Stage1VerificationError(f"Stage 1 binary is not a regular file: {binary}")
+
+    checker = executable_check or os.access
+    if not checker(binary, os.X_OK):
+        raise Stage1VerificationError(f"Stage 1 binary is not executable: {binary}")
+    return root, binary
+
+
+def resolve_regular_file(root: Path, path: Path, label: str) -> Path:
+    require_within_root(root, path, label)
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        raise Stage1VerificationError(
+            f"could not resolve {label} {path}: {exc}"
+        ) from exc
+    require_within_root(root, resolved, label)
+    if resolved != path:
+        raise Stage1VerificationError(f"{label} path must not contain symlinks: {path}")
+    if not resolved.is_file():
+        raise Stage1VerificationError(f"{label} is not a regular file: {resolved}")
+    return resolved
+
+
+def read_build_id(path: Path, section: str) -> str:
+    parser = configparser.ConfigParser(
+        interpolation=None,
+        strict=True,
+        empty_lines_in_values=False,
+    )
+    parser.optionxform = str
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            parser.read_file(stream, source=str(path))
+    except (OSError, UnicodeError, configparser.Error) as exc:
+        raise Stage1VerificationError(f"could not parse {path}: {exc}") from exc
+
+    if not parser.has_section(section):
+        raise Stage1VerificationError(f"missing [{section}] section in {path}")
+    if not parser.has_option(section, "BuildID"):
+        raise Stage1VerificationError(f"missing [{section}] BuildID in {path}")
+    return validate_build_id(parser.get(section, "BuildID", raw=True))
+
+
+def read_binary_arch(
+    binary: Path,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> str:
+    command_runner = runner or subprocess.run
+    try:
+        result = command_runner(
+            [LIPO, "-archs", str(binary)],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise Stage1VerificationError(
+            f"could not inspect Stage 1 binary: {exc}"
+        ) from exc
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        detail = f": {stderr}" if stderr else ""
+        raise Stage1VerificationError(
+            f"{LIPO} failed with exit code {result.returncode}{detail}"
+        )
+    arches = (result.stdout or "").split()
+    if len(arches) != 1:
+        raise Stage1VerificationError(
+            "Stage 1 binary must contain exactly one architecture; "
+            f"found {arches or 'none'}"
+        )
+    return arches[0]
+
+
+def verify_stage1(
+    workspace_root: Path,
+    search_root: Path,
+    expected_build_id: str,
+    expected_arch: str,
+    *,
+    machine: str | None = None,
+    lipo_runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    executable_check: Callable[[Path, int], bool] | None = None,
+) -> Stage1Identity:
+    expected_id = validate_build_id(expected_build_id)
+    if expected_arch not in SUPPORTED_ARCHES:
+        raise Stage1VerificationError(
+            f"unsupported expected architecture: {expected_arch}"
+        )
+
+    runner_arch = machine if machine is not None else platform.machine()
+    if runner_arch != expected_arch:
+        raise Stage1VerificationError(
+            f"runner architecture mismatch: expected {expected_arch}, got {runner_arch}"
+        )
+
+    root, binary = discover_binary(workspace_root, search_root, executable_check)
+    binary_arch = read_binary_arch(binary, lipo_runner)
+    if binary_arch != expected_arch:
+        raise Stage1VerificationError(
+            f"binary architecture mismatch: expected {expected_arch}, got {binary_arch}"
+        )
+
+    resources = binary.parent.parent / "Resources"
+    application_ini = resolve_regular_file(
+        root, resources / "application.ini", "application.ini"
+    )
+    platform_ini = resolve_regular_file(
+        root, resources / "platform.ini", "platform.ini"
+    )
+    application_build_id = read_build_id(application_ini, "App")
+    platform_build_id = read_build_id(platform_ini, "Build")
+    for label, actual in (
+        ("application", application_build_id),
+        ("platform", platform_build_id),
+    ):
+        if actual != expected_id:
+            raise Stage1VerificationError(
+                f"{label} BuildID mismatch: expected {expected_id}, got {actual}"
+            )
+
+    print(f"Stage 1 app binary: {binary}")
+    print(f"Stage 1 runner architecture: {runner_arch}")
+    print(f"Stage 1 binary architecture: {binary_arch}")
+    print(f"Stage 1 application.ini: {application_ini}")
+    print(f"Stage 1 application BuildID: {application_build_id}")
+    print(f"Stage 1 platform.ini: {platform_ini}")
+    print(f"Stage 1 platform BuildID: {platform_build_id}")
+
+    return Stage1Identity(
+        binary=binary,
+        runner_arch=runner_arch,
+        binary_arch=binary_arch,
+        application_build_id=application_build_id,
+        platform_build_id=platform_build_id,
+    )
+
+
+def write_github_output(path: Path, name: str, value: str) -> None:
+    if any(character in value for character in ("\r", "\n")):
+        raise Stage1VerificationError(f"{name} contains a line break")
+    try:
+        with path.open("a", encoding="utf-8", newline="\n") as stream:
+            stream.write(f"{name}={value}\n")
+    except OSError as exc:
+        raise Stage1VerificationError(f"could not write GitHub output: {exc}") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify a macOS PGO Stage 1 bundle without launching it"
+    )
+    parser.add_argument("--workspace-root", required=True, type=Path)
+    parser.add_argument("--search-root", required=True, type=Path)
+    parser.add_argument("--expected-build-id", required=True)
+    parser.add_argument("--expected-arch", required=True)
+    parser.add_argument("--github-output", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        identity = verify_stage1(
+            args.workspace_root,
+            args.search_root,
+            args.expected_build_id,
+            args.expected_arch,
+        )
+        write_github_output(
+            args.github_output,
+            "app_binary",
+            str(identity.binary),
+        )
+    except Stage1VerificationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- replace the macOS PGO Stage 1 direct instrumented `--full-version` probe with non-launching bundle validation
- require one executable native app, the expected thin Mach-O slice, and matching `application.ini` / `platform.ini` BuildIDs
- anchor the selected app and metadata under `GITHUB_WORKSPACE` and reject symlink or non-regular-file escapes
- keep the canonical `profileserver.py` path unchanged and fail if either generated profile output is missing or empty
- keep final universal DMG native `--full-version` verifiers unchanged

## Context

Validation-only run 30067776932 reached the new Stage 1 probe after both mac producer jobs succeeded, then exited 132 on Intel and 133 on arm64 before profile generation. The exact internal trap cause is unproven. This fix restores the supported profile-generation boundary without treating static metadata as final runtime proof.

## Local validation

- 53 Python tests passed, including the new mac Stage 1 positive and fail-closed cases
- Ruff check and format check passed
- workflow YAML parsing and Prettier check passed
- `git diff --check` passed
- two independent read-only reviews found no remaining P0/P1/P2 issues

## Required Actions proof before merge

Run `Daily Runtime Build` on this exact branch/head with:

- `debug=false`
- `pgo=true`
- `validation_only=true`

The run must pass both mac part2 jobs, produce nonempty profdata and jarlog artifacts, pass both mac part3 jobs and PGO integration, and pass both final native universal-DMG verifiers. Android and all publication jobs must remain skipped.
