### PR TITLE
fix(linux): restore XDG profile paths for Floorp

### DIFF
--- a/.github/patches/upstream/nxXREDirProvider.cpp.patch
+++ b/.github/patches/upstream/nxXREDirProvider.cpp.patch
@@ -1,8 +1,85 @@
 diff --git a/toolkit/xre/nsXREDirProvider.cpp b/toolkit/xre/nsXREDirProvider.cpp
-index 3b4612e02c..3c02531e26 100644
+index fea288aa5b6..5a8796ea507 100644
 --- a/toolkit/xre/nsXREDirProvider.cpp
 +++ b/toolkit/xre/nsXREDirProvider.cpp
-@@ -1253,10 +1253,10 @@ nsresult nsXREDirProvider::AppendProfilePath(nsIFile* aFile, bool aLocal) {
+@@ -1317,10 +1317,20 @@ bool nsXREDirProvider::IsForceLegacyHome() {
+ #  else
+   return true;
+ #  endif
+ }
+ 
++static bool IsOfficialFloorpAppData() {
++  return gAppData && gAppData->vendor && gAppData->name && gAppData->profile &&
++         nsDependentCString(gAppData->vendor)
++             .Equals("Ablaze"_ns, nsCaseInsensitiveCStringComparator) &&
++         nsDependentCString(gAppData->name)
++             .Equals("Floorp"_ns, nsCaseInsensitiveCStringComparator) &&
++         nsDependentCString(gAppData->profile)
++             .Equals("Floorp"_ns, nsCaseInsensitiveCStringComparator);
++}
++
+ /* static */
+ nsresult nsXREDirProvider::AppendFromAppData(nsIFile* aFile, bool aIsDotted) {
+   // This might happen in xpcshell so assert that it is indeed in a xpcshell
+   // test. This assumes the xpcshell are ran through test harness.
+   if (!gAppData) {
+@@ -1332,12 +1342,17 @@ nsresult nsXREDirProvider::AppendFromAppData(nsIFile* aFile, bool aIsDotted) {
+ 
+   // Similar to nsXREDirProvider::AppendProfilePath.
+   // TODO: Bug 1990407 - Evaluate if refactoring might be required there in the
+   // future?
+   if (gAppData->profile) {
+-    nsAutoCString profile;
+-    profile = gAppData->profile;
++    nsAutoCString profile(gAppData->profile);
++    if (IsOfficialFloorpAppData()) {
++      ToLowerCase(profile);
++      if (aIsDotted) {
++        profile.Insert('.', 0);
++      }
++    }
+     MOZ_TRY(aFile->AppendRelativeNativePath(profile));
+   } else {
+     nsAutoCString vendor;
+     nsAutoCString appName;
+     vendor = gAppData->vendor;
+@@ -1380,12 +1395,13 @@ bool nsXREDirProvider::LegacyHomeExists(nsIFile** aFile) {
+   NS_ENSURE_SUCCESS(rv, false);
+ 
+   rv = localDir->Exists(&exists);
+   NS_ENSURE_SUCCESS(rv, false);
+ 
+-  // Give a chance to (3)
+-  if (!exists) {
++  // Give a chance to (3). Official Floorp has never used MOZ_USER_DIR as its
++  // product profile root.
++  if (!exists && !IsOfficialFloorpAppData()) {
+     nsCOMPtr<nsIFile> userDir;
+     rv = parentDir->Clone(getter_AddRefs(userDir));
+     NS_ENSURE_SUCCESS(rv, false);
+ 
+     nsAutoCString mozUserDir;
+@@ -1510,13 +1526,14 @@ nsresult nsXREDirProvider::GetLegacyOrXDGHomePath(const char* aHomeDir,
+           PR_GetEnv("XPCSHELL_TEST_PROFILE_DIR");
+       MOZ_ASSERT(xpcshell, "gAppData can only be nullptr in xpcshell tests");
+       return NS_OK;
+     }
+ 
+-    // If the build was made against a specific profile name, MOZ_APP_PROFILE=
+-    // then make sure we respect this and dont move to XDG directory
+-    if (gAppData->profile) {
++    // Keep MOZ_APP_PROFILE builds on legacy home, except official Floorp,
++    // whose existing legacy root was handled above and whose fresh profiles
++    // use XDG.
++    if (gAppData->profile && !IsOfficialFloorpAppData()) {
+       MOZ_TRY(NS_NewNativeLocalFile(nsDependentCString(aHomeDir),
+                                     getter_AddRefs(localDir)));
+     } else {
+       MOZ_TRY(GetLegacyOrXDGConfigHome(aHomeDir, getter_AddRefs(localDir)));
+       MOZ_TRY(localDir->Clone(getter_AddRefs(parentDir)));
+@@ -1576,14 +1593,14 @@ nsresult nsXREDirProvider::AppendProfilePath(nsIFile* aFile, bool aLocal) {
+ 
+ #elif defined(XP_WIN)
    if (!profile.IsEmpty()) {
      rv = AppendProfileString(aFile, profile.get());
    } else {
@@ -17,3 +94,5 @@ index 3b4612e02c..3c02531e26 100644
      rv = aFile->AppendNative(appName);
    }
    NS_ENSURE_SUCCESS(rv, rv);
+ 
+ #elif defined(ANDROID)

--- a/.github/patches/upstream/toolkit-tests-gtest-TestXREAppDir.cpp.patch
+++ b/.github/patches/upstream/toolkit-tests-gtest-TestXREAppDir.cpp.patch
@@ -1,0 +1,259 @@
+diff --git a/toolkit/tests/gtest/TestXREAppDir.cpp b/toolkit/tests/gtest/TestXREAppDir.cpp
+index c5376749b4e4b87677ac11ee203a53cfcc3d4233..4917906bf60dfd34cfc774e9e043d03d4c197799 100644
+--- a/toolkit/tests/gtest/TestXREAppDir.cpp
++++ b/toolkit/tests/gtest/TestXREAppDir.cpp
+@@ -36,6 +36,9 @@ using namespace mozilla;
+ class BaseXREAppDir : public ::testing::Test {
+  protected:
+   void SetUp() override {
++    mInitialAppData = gAppData;
++    ASSERT_NE(mInitialAppData, nullptr);
++
+ // There is no need to mock on macOS because nsXREDirProvider relies on macOS
+ // level APIs, see below
+ #if defined(XP_UNIX) && !defined(XP_MACOSX)
+@@ -121,13 +124,7 @@ class BaseXREAppDir : public ::testing::Test {
+       SwitchFakeAppDataOff();
+     }
+ 
+-    EXPECT_STREQ(gAppData->profile, nullptr);
+-#if defined(ANDROID)
+-    EXPECT_STREQ(gAppData->name, "Fennec");
+-#else
+-    EXPECT_STREQ(gAppData->name, "Firefox");
+-#endif
+-    EXPECT_STREQ(gAppData->vendor, "Mozilla");
++    EXPECT_EQ(gAppData, mInitialAppData);
+   }
+ 
+   nsCString GetPath(nsCOMPtr<nsIFile> aFile) {
+@@ -147,9 +144,13 @@ class BaseXREAppDir : public ::testing::Test {
+ 
+   void SwitchFakeAppDataOff() {
+     EXPECT_NE(mOriginalAppData, nullptr);
+-    gAppData = mOriginalAppData;
++    EXPECT_EQ(gAppData, &mFakeAppData);
++
++    const XREAppData* originalAppData = mOriginalAppData;
+     mOriginalAppData = nullptr;
+-    EXPECT_STREQ(gAppData->profile, nullptr);
++    gAppData = originalAppData;
++
++    EXPECT_EQ(gAppData, mInitialAppData);
+   }
+ 
+   // Used by
+@@ -158,8 +159,8 @@ class BaseXREAppDir : public ::testing::Test {
+   //  - NS_APP_APPLICATION_REGISTRY_FILE
+   nsCString GetUserAppDataDirectory() {
+     nsCOMPtr<nsIFile> localDir;
+-    nsresult rv = NS_OK;
+-    nsXREDirProvider::GetUserAppDataDirectory(getter_AddRefs(localDir));
++    nsresult rv =
++        nsXREDirProvider::GetUserAppDataDirectory(getter_AddRefs(localDir));
+     EXPECT_NS_SUCCEEDED(rv);
+     return GetPath(localDir);
+   }
+@@ -289,6 +290,7 @@ class BaseXREAppDir : public ::testing::Test {
+   nsCString mRoamingHome;
+ #endif
+ 
++  const XREAppData* mInitialAppData = nullptr;
+   const XREAppData* mOriginalAppData = nullptr;
+   XREAppData mFakeAppData{};
+ };
+@@ -2087,3 +2089,194 @@ TEST_F(CacheXREAppDir_Env, GetUserProfilesLocalDir) {
+           ,
+       GetUserProfilesLocalDir());
+ }
++
++#if defined(MOZ_WIDGET_GTK)
++class FloorpXREAppDir : public XDGXREAppDir_NoEnv_AppDataProfile {
++ protected:
++  void SetUp() override {
++    XDGXREAppDir_NoEnv_AppDataProfile::SetUp();
++    mFakeAppData.vendor = "Ablaze";
++    mFakeAppData.name = "Floorp";
++    mFakeAppData.profile = "Floorp";
++    UnsetEnv("XDG_CACHE_HOME");
++    UnsetEnv("MOZ_APP_DATA");
++    UnsetEnv("MOZ_LOCAL_APP_DATA");
++  }
++
++  nsCString HomePath(const char* aRelativePath) {
++    nsCString path(mMockedHomeDir);
++    path.Append('/');
++    path.Append(aRelativePath);
++    return path;
++  }
++
++  void ExpectDataRoots(const nsCString& aConfigRoot,
++                       const nsCString& aCacheRoot) {
++    EXPECT_EQ(aConfigRoot, GetUserAppDataDirectory());
++    EXPECT_EQ(aConfigRoot, GetUserProfilesRootDir());
++    EXPECT_EQ(aCacheRoot, GetUserLocalDataDirectory());
++    EXPECT_EQ(aCacheRoot, GetUserProfilesLocalDir());
++  }
++
++  bool PathExists(const nsACString& aPath) {
++    nsCOMPtr<nsIFile> path;
++    nsresult rv = NS_NewNativeLocalFile(aPath, getter_AddRefs(path));
++    EXPECT_NS_SUCCEEDED(rv);
++    if (NS_FAILED(rv)) {
++      return false;
++    }
++
++    bool exists = false;
++    rv = path->Exists(&exists);
++    EXPECT_NS_SUCCEEDED(rv);
++    return NS_SUCCEEDED(rv) && exists;
++  }
++
++  void MakeHomeSubdir(const char* aRelativePath) {
++    nsCString path;
++    MkHomeSubdir(aRelativePath, path);
++  }
++
++  void UseCustomXDGConfigHome() {
++    MkHomeSubdir(".xdgConfigDir", mXdgConfigDir);
++    SetEnv("XDG_CONFIG_HOME", mXdgConfigDir.get());
++  }
++
++  void UseCustomXDGCacheHome() {
++    MkHomeSubdir(".xdgCacheDir", mXdgCacheDir);
++    SetEnv("XDG_CACHE_HOME", mXdgCacheDir.get());
++  }
++
++  nsCString mXdgConfigDir;
++  nsCString mXdgCacheDir;
++};
++
++TEST_F(FloorpXREAppDir, FreshHomeUsesDefaultXDGPaths) {
++  ExpectDataRoots(HomePath(".config/floorp"), HomePath(".cache/floorp"));
++  EXPECT_TRUE(PathExists(HomePath(".config/floorp")));
++  EXPECT_TRUE(PathExists(HomePath(".cache/floorp")));
++  EXPECT_FALSE(PathExists(HomePath(".config/.floorp")));
++  EXPECT_FALSE(PathExists(HomePath(".config/Floorp")));
++  EXPECT_FALSE(PathExists(HomePath(".cache/Floorp")));
++  EXPECT_FALSE(PathExists(HomePath(".floorp")));
++  EXPECT_FALSE(PathExists(HomePath("Floorp")));
++}
++
++TEST_F(FloorpXREAppDir, FreshHomeUsesCustomXDGPaths) {
++  UseCustomXDGConfigHome();
++  UseCustomXDGCacheHome();
++
++  ExpectDataRoots(nsCString(mXdgConfigDir + "/floorp"_ns),
++                  nsCString(mXdgCacheDir + "/floorp"_ns));
++  EXPECT_FALSE(PathExists(mXdgConfigDir + "/.floorp"_ns));
++  EXPECT_FALSE(PathExists(mXdgCacheDir + "/.floorp"_ns));
++  EXPECT_FALSE(PathExists(mXdgConfigDir + "/Floorp"_ns));
++  EXPECT_FALSE(PathExists(mXdgCacheDir + "/Floorp"_ns));
++  EXPECT_FALSE(PathExists(HomePath(".floorp")));
++  EXPECT_FALSE(PathExists(HomePath("Floorp")));
++}
++
++TEST_F(FloorpXREAppDir, RelativeXDGPathsFallBackToDefaults) {
++  SetEnv("MOZ_LEGACY_HOME", "0");
++  SetEnv("XDG_CONFIG_HOME", "relative-config");
++  SetEnv("XDG_CACHE_HOME", "relative-cache");
++
++  ExpectDataRoots(HomePath(".config/floorp"), HomePath(".cache/floorp"));
++  EXPECT_FALSE(PathExists(HomePath(".floorp")));
++  EXPECT_FALSE(PathExists(HomePath("Floorp")));
++}
++
++TEST_F(FloorpXREAppDir, ExistingEmptyLegacyRootWins) {
++  SetEnv("MOZ_LEGACY_HOME", "0");
++  MakeHomeSubdir(".floorp");
++
++  ExpectDataRoots(HomePath(".floorp"), HomePath(".cache/floorp"));
++  EXPECT_FALSE(PathExists(HomePath(".config/floorp")));
++  EXPECT_FALSE(PathExists(HomePath("Floorp")));
++}
++
++TEST_F(FloorpXREAppDir, ExistingLegacyRootWinsOverXDGRoot) {
++  MakeHomeSubdir(".floorp");
++  UseCustomXDGConfigHome();
++  MakeHomeSubdir(".xdgConfigDir/floorp");
++
++  ExpectDataRoots(HomePath(".floorp"), HomePath(".cache/floorp"));
++  EXPECT_TRUE(PathExists(mXdgConfigDir + "/floorp"_ns));
++  EXPECT_FALSE(PathExists(HomePath("Floorp")));
++}
++
++TEST_F(FloorpXREAppDir, ForcedLegacyKeepsXDGCache) {
++  SetEnv("MOZ_LEGACY_HOME", "1");
++  UseCustomXDGConfigHome();
++  UseCustomXDGCacheHome();
++
++  ExpectDataRoots(HomePath(".floorp"), nsCString(mXdgCacheDir + "/floorp"_ns));
++  EXPECT_FALSE(PathExists(mXdgConfigDir + "/floorp"_ns));
++  EXPECT_FALSE(PathExists(mXdgCacheDir + "/.floorp"_ns));
++  EXPECT_FALSE(PathExists(mXdgCacheDir + "/Floorp"_ns));
++  EXPECT_FALSE(PathExists(HomePath("Floorp")));
++}
++
++TEST_F(FloorpXREAppDir, ExistingCapitalizedMarkerDoesNotSelectLegacy) {
++  MakeHomeSubdir("Floorp");
++
++  ExpectDataRoots(HomePath(".config/floorp"), HomePath(".cache/floorp"));
++  EXPECT_TRUE(PathExists(HomePath("Floorp")));
++  EXPECT_FALSE(PathExists(HomePath(".floorp")));
++}
++
++TEST_F(FloorpXREAppDir, ExistingMozillaRootDoesNotSelectLegacy) {
++  MakeHomeSubdir("mozilla");
++
++  ExpectDataRoots(HomePath(".config/floorp"), HomePath(".cache/floorp"));
++  EXPECT_TRUE(PathExists(HomePath("mozilla")));
++  EXPECT_FALSE(PathExists(HomePath(".floorp")));
++  EXPECT_FALSE(PathExists(HomePath("Floorp")));
++}
++
++TEST_F(FloorpXREAppDir, OfficialIdentityComparisonIsCaseInsensitive) {
++  mFakeAppData.vendor = "aBlAzE";
++  mFakeAppData.name = "fLoOrP";
++  mFakeAppData.profile = "FLOORP";
++  SetEnv("MOZ_LEGACY_HOME", "0");
++
++  ExpectDataRoots(HomePath(".config/floorp"), HomePath(".cache/floorp"));
++  EXPECT_FALSE(PathExists(HomePath(".config/FLOORP")));
++  EXPECT_FALSE(PathExists(HomePath(".cache/FLOORP")));
++  EXPECT_FALSE(PathExists(HomePath(".floorp")));
++  EXPECT_FALSE(PathExists(HomePath("Floorp")));
++}
++
++TEST_F(FloorpXREAppDir, NonOfficialVendorRetainsNamedProfileBehavior) {
++  mFakeAppData.vendor = "Example Distribution";
++
++  ExpectDataRoots(HomePath(".floorp"), HomePath(".cache/floorp"));
++  EXPECT_TRUE(PathExists(HomePath("Floorp")));
++  EXPECT_FALSE(PathExists(HomePath(".config/floorp")));
++}
++
++TEST_F(FloorpXREAppDir, NonOfficialNameRetainsNamedProfileBehavior) {
++  mFakeAppData.name = "Floorp Community";
++
++  ExpectDataRoots(HomePath(".floorp"), HomePath(".cache/floorp"));
++  EXPECT_TRUE(PathExists(HomePath("Floorp")));
++  EXPECT_FALSE(PathExists(HomePath(".config/floorp")));
++}
++
++TEST_F(FloorpXREAppDir, NonOfficialProfileRetainsNamedProfileBehavior) {
++  mFakeAppData.profile = "FloorpFork";
++
++  ExpectDataRoots(HomePath(".floorpfork"), HomePath(".cache/floorpfork"));
++  EXPECT_TRUE(PathExists(HomePath("FloorpFork")));
++  EXPECT_FALSE(PathExists(HomePath(".config/floorpfork")));
++}
++
++TEST_F(FloorpXREAppDir, NoranekoRetainsNamedProfileBehavior) {
++  mFakeAppData.vendor = "Noraneko Community";
++  mFakeAppData.profile = "Noraneko";
++
++  ExpectDataRoots(HomePath(".noraneko"), HomePath(".cache/noraneko"));
++  EXPECT_TRUE(PathExists(HomePath("Noraneko")));
++  EXPECT_FALSE(PathExists(HomePath(".config/noraneko")));
++}
++#endif  // defined(MOZ_WIDGET_GTK)

--- a/.github/workflows/scripts/test_verify_linux_profile_paths.py
+++ b/.github/workflows/scripts/test_verify_linux_profile_paths.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import verify_linux_profile_paths as verifier
+
+FAKE_BROWSER = r"""
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+MODE = __MODE__
+arguments = sys.argv[1:]
+if len(arguments) != 4 or arguments[:3] != ["--headless", "--no-remote", "--createprofile"]:
+    print("unexpected command: " + repr(arguments), file=sys.stderr)
+    raise SystemExit(9)
+
+name = arguments[3]
+home = Path(os.environ["HOME"])
+
+def xdg_base(variable, fallback):
+    value = os.environ.get(variable)
+    if value and Path(value).is_absolute():
+        return Path(value)
+    return home / fallback
+
+config_base = xdg_base("XDG_CONFIG_HOME", ".config")
+cache_base = xdg_base("XDG_CACHE_HOME", ".cache")
+legacy = (home / ".floorp").exists() or os.environ.get("MOZ_LEGACY_HOME", "").startswith("1")
+config_root = home / ".floorp" if legacy else config_base / "floorp"
+cache_root = cache_base / "floorp"
+child = "abcdefgh." + name
+
+config_profile = config_root / child
+cache_profile = cache_root / child
+config_profile.mkdir(parents=True, exist_ok=True)
+targeted = name.endswith("fresh-default")
+if not (MODE == "missing-cache" and targeted):
+    cache_profile.mkdir(parents=True, exist_ok=True)
+    (cache_profile / "cache-marker").write_text("cache", encoding="utf-8")
+(config_profile / "profile-marker").write_text("profile", encoding="utf-8")
+
+profile_path = "../escaped" if MODE == "escaping-profile" and targeted else child
+(config_root / "profiles.ini").write_text(
+    "[Profile0]\n"
+    f"Name={name}\n"
+    "IsRelative=1\n"
+    f"Path={profile_path}\n"
+    "\n"
+    "[General]\n"
+    "StartWithLastProfile=1\n"
+    "Version=2\n",
+    encoding="utf-8",
+)
+
+if MODE == "capital-write" and targeted:
+    marker = home / "Floorp"
+    marker.mkdir(exist_ok=True)
+    (marker / "unexpected").write_text("bad", encoding="utf-8")
+if MODE == "legacy-marker-write" and targeted:
+    (home / ".floorp").mkdir(exist_ok=True)
+if MODE == "capital-xdg-write" and targeted:
+    (config_base / "Floorp").mkdir(parents=True, exist_ok=True)
+    (cache_base / "Floorp").mkdir(parents=True, exist_ok=True)
+if MODE == "error-log" and targeted:
+    print("Error creating profile.", file=sys.stderr)
+if MODE == "nonzero" and targeted:
+    raise SystemExit(7)
+if MODE == "hang" and targeted:
+    marker = home / "child-signal.txt"
+    child_code = '''
+import signal
+import sys
+import time
+from pathlib import Path
+marker = Path(sys.argv[1])
+def terminated(signum, frame):
+    marker.write_text("terminated", encoding="utf-8")
+    raise SystemExit(0)
+signal.signal(signal.SIGTERM, terminated)
+marker.write_text("ready", encoding="utf-8")
+while True:
+    time.sleep(1)
+'''
+    subprocess.Popen([sys.executable, "-c", child_code, str(marker)])
+    deadline = time.monotonic() + 2
+    while not marker.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    time.sleep(60)
+print("created " + name)
+"""
+
+
+@unittest.skipUnless(sys.platform.startswith("linux"), "Linux-only verifier")
+class LinuxProfilePathVerifierTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(
+            prefix="floorp-2601-verifier-test-", dir="/tmp"
+        )
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def make_browser(self, mode: str = "pass") -> Path:
+        binary = self.root / f"fake-floorp-{mode}"
+        source = textwrap.dedent(FAKE_BROWSER).replace("__MODE__", repr(mode)).lstrip()
+        binary.write_text(source, encoding="utf-8", newline="\n")
+        binary.chmod(0o755)
+        return binary
+
+    def run_matrix(self, mode: str = "pass") -> tuple[dict, Path, Path]:
+        work = self.root / f"work-{mode}"
+        results = self.root / f"results-{mode}.json"
+        summary = verifier.run_verification(
+            self.make_browser(mode), work, results, timeout=5
+        )
+        return summary, work, results
+
+    def test_complete_matrix_passes_and_preserves_evidence(self) -> None:
+        summary, work, results = self.run_matrix()
+
+        self.assertTrue(summary["success"])
+        self.assertEqual(summary["counts"], {"total": 8, "passed": 8, "failed": 0})
+        self.assertEqual(json.loads(results.read_text(encoding="utf-8")), summary)
+        self.assertEqual(
+            [case["name"] for case in summary["cases"]],
+            [spec.name for spec in verifier.CASES],
+        )
+
+        cases = {case["name"]: case for case in summary["cases"]}
+        self.assertEqual(
+            Path(cases["fresh-default"]["expected"]["config_root"]),
+            work / "state" / "fresh-default" / "home" / ".config" / "floorp",
+        )
+        self.assertEqual(
+            Path(cases["custom-xdg"]["expected"]["cache_root"]),
+            work / "state" / "custom-xdg" / "xdg-cache" / "floorp",
+        )
+        self.assertEqual(
+            Path(cases["forced-legacy-xdg-cache"]["expected"]["config_root"]),
+            work / "state" / "forced-legacy-xdg-cache" / "home" / ".floorp",
+        )
+        self.assertEqual(
+            Path(cases["forced-legacy-xdg-cache"]["expected"]["cache_root"]),
+            work / "state" / "forced-legacy-xdg-cache" / "xdg-cache" / "floorp",
+        )
+
+        for case in summary["cases"]:
+            self.assertEqual(case["status"], "passed")
+            self.assertEqual(
+                case["process"]["command"][1:4],
+                ["--headless", "--no-remote", "--createprofile"],
+            )
+            self.assertFalse(case["process"]["timed_out"])
+            self.assertEqual(case["process"]["return_code"], 0)
+            self.assertEqual(
+                Path(case["profile"]["config_profile"]).name,
+                Path(case["profile"]["cache_profile"]).name,
+            )
+            for artifact in case["artifacts"].values():
+                self.assertTrue(Path(artifact).is_file(), artifact)
+            profiles_evidence = json.loads(
+                Path(case["artifacts"]["profiles_ini"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(len(profiles_evidence["files"]), 1)
+            self.assertIn(
+                f"Name={case['profile_name']}",
+                profiles_evidence["files"][0]["content"],
+            )
+
+    def test_missing_matching_cache_child_fails_only_target_case(self) -> None:
+        summary, _, results = self.run_matrix("missing-cache")
+
+        self.assertFalse(summary["success"])
+        self.assertEqual(summary["counts"], {"total": 8, "passed": 7, "failed": 1})
+        failed = [case for case in summary["cases"] if case["status"] == "failed"]
+        self.assertEqual([case["name"] for case in failed], ["fresh-default"])
+        self.assertIn("matching cache profile child is missing", failed[0]["errors"][0])
+        self.assertFalse(json.loads(results.read_text(encoding="utf-8"))["success"])
+
+    def test_zero_exit_with_create_profile_error_is_rejected(self) -> None:
+        summary, _, _ = self.run_matrix("error-log")
+
+        failed = [case for case in summary["cases"] if case["status"] == "failed"]
+        self.assertEqual([case["name"] for case in failed], ["fresh-default"])
+        self.assertEqual(failed[0]["process"]["return_code"], 0)
+        self.assertIn("Error creating profile.", failed[0]["errors"][0])
+
+    def test_unexpected_capital_floorp_creation_is_rejected(self) -> None:
+        summary, _, _ = self.run_matrix("capital-write")
+
+        failed = [case for case in summary["cases"] if case["status"] == "failed"]
+        self.assertEqual([case["name"] for case in failed], ["fresh-default"])
+        self.assertIn("unexpected ~/Floorp was created", failed[0]["errors"][0])
+
+    def test_unexpected_legacy_marker_creation_is_rejected(self) -> None:
+        summary, _, _ = self.run_matrix("legacy-marker-write")
+
+        failed = [case for case in summary["cases"] if case["status"] == "failed"]
+        self.assertEqual([case["name"] for case in failed], ["fresh-default"])
+        self.assertIn("unexpected ~/.floorp", failed[0]["errors"][0])
+
+    def test_unexpected_capitalized_xdg_sibling_is_rejected(self) -> None:
+        summary, _, _ = self.run_matrix("capital-xdg-write")
+
+        failed = [case for case in summary["cases"] if case["status"] == "failed"]
+        self.assertEqual([case["name"] for case in failed], ["fresh-default"])
+        self.assertIn("unexpected capitalized Floorp sibling", failed[0]["errors"][0])
+
+    def test_escaping_profile_descriptor_is_rejected(self) -> None:
+        summary, _, _ = self.run_matrix("escaping-profile")
+
+        failed = [case for case in summary["cases"] if case["status"] == "failed"]
+        self.assertEqual([case["name"] for case in failed], ["fresh-default"])
+        self.assertIn("one direct child", failed[0]["errors"][0])
+
+    def test_timeout_terminates_the_browser_process_group(self) -> None:
+        work = self.root / "work-hang"
+        results = self.root / "results-hang.json"
+        summary = verifier.run_verification(
+            self.make_browser("hang"), work, results, timeout=0.5
+        )
+
+        failed = [case for case in summary["cases"] if case["status"] == "failed"]
+        self.assertEqual([case["name"] for case in failed], ["fresh-default"])
+        self.assertTrue(failed[0]["process"]["timed_out"])
+        self.assertEqual(
+            (work / "state" / "fresh-default" / "home" / "child-signal.txt").read_text(
+                encoding="utf-8"
+            ),
+            "terminated",
+        )
+
+    def test_cli_success_writes_machine_readable_summary(self) -> None:
+        work = self.root / "cli-work"
+        results = self.root / "cli-results.json"
+        return_code = verifier.main([
+            "--binary",
+            str(self.make_browser()),
+            "--work-dir",
+            str(work),
+            "--results-json",
+            str(results),
+            "--timeout",
+            "5",
+        ])
+
+        self.assertEqual(return_code, 0)
+        self.assertTrue(json.loads(results.read_text(encoding="utf-8"))["success"])
+
+    def test_cli_rejects_mnt_backed_work_path_and_records_fatal_result(self) -> None:
+        results = self.root / "mnt-fatal.json"
+        return_code = verifier.main([
+            "--binary",
+            str(self.make_browser()),
+            "--work-dir",
+            "/mnt/c/floorp-2601-verifier-test",
+            "--results-json",
+            str(results),
+        ])
+
+        self.assertEqual(return_code, 2)
+        fatal = json.loads(results.read_text(encoding="utf-8"))
+        self.assertEqual(fatal["status"], "fatal")
+        self.assertIn("not under /mnt", fatal["fatal_error"])
+
+    def test_cli_rejects_relative_work_path(self) -> None:
+        results = self.root / "relative-fatal.json"
+        return_code = verifier.main([
+            "--binary",
+            str(self.make_browser()),
+            "--work-dir",
+            "relative-work",
+            "--results-json",
+            str(results),
+        ])
+
+        self.assertEqual(return_code, 2)
+        fatal = json.loads(results.read_text(encoding="utf-8"))
+        self.assertIn("must be absolute", fatal["fatal_error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/scripts/verify_linux_profile_paths.py
+++ b/.github/workflows/scripts/verify_linux_profile_paths.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import os
+import platform
+import re
+import signal
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+PROFILE_SECTION_RE = re.compile(r"Profile[0-9]+", re.ASCII)
+CREATE_PROFILE_ERROR = b"Error creating profile."
+DEFAULT_TIMEOUT_SECONDS = 45.0
+MAX_TIMEOUT_SECONDS = 300.0
+
+
+class ProfilePathVerificationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class CaseSpec:
+    name: str
+    config_mode: str = "default"
+    cache_mode: str = "default"
+    legacy_marker: bool = False
+    force_legacy: bool = False
+    floorp_marker: bool = False
+    mozilla_marker: bool = False
+    precreate_xdg_product: bool = False
+
+
+@dataclass(frozen=True)
+class CaseContext:
+    spec: CaseSpec
+    root: Path
+    evidence_root: Path
+    home: Path
+    config_base: Path
+    cache_base: Path
+    expected_config_root: Path
+    expected_cache_root: Path
+    profile_name: str
+    environment: dict[str, str]
+    protected_paths: tuple[Path, ...]
+    protected_before: dict[str, dict[str, Any]]
+
+
+CASES = (
+    CaseSpec("fresh-default"),
+    CaseSpec("custom-xdg", config_mode="custom", cache_mode="custom"),
+    CaseSpec("relative-xdg-fallback", config_mode="relative", cache_mode="relative"),
+    CaseSpec("existing-empty-legacy", legacy_marker=True),
+    CaseSpec(
+        "legacy-and-xdg",
+        config_mode="custom",
+        cache_mode="custom",
+        legacy_marker=True,
+        precreate_xdg_product=True,
+    ),
+    CaseSpec(
+        "forced-legacy-xdg-cache",
+        config_mode="custom",
+        cache_mode="custom",
+        force_legacy=True,
+    ),
+    CaseSpec("capital-floorp-ignored", floorp_marker=True),
+    CaseSpec("mozilla-ignored", mozilla_marker=True),
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _is_under_mnt(path: Path) -> bool:
+    return len(path.parts) >= 2 and path.parts[0] == "/" and path.parts[1] == "mnt"
+
+
+def _reject_mnt_path(path: Path, label: str) -> None:
+    absolute = Path(os.path.abspath(path))
+    resolved = absolute.resolve(strict=False)
+    if _is_under_mnt(absolute) or _is_under_mnt(resolved):
+        raise ProfilePathVerificationError(
+            f"{label} must be on a native Linux filesystem, not under /mnt: {path}"
+        )
+
+
+def validate_binary(binary: Path) -> Path:
+    if not binary.is_absolute():
+        raise ProfilePathVerificationError("binary path must be absolute")
+    _reject_mnt_path(binary, "binary")
+    try:
+        resolved = binary.resolve(strict=True)
+    except OSError as exc:
+        raise ProfilePathVerificationError(f"could not resolve binary: {exc}") from exc
+    if not resolved.is_file():
+        raise ProfilePathVerificationError(f"binary is not a regular file: {resolved}")
+    if not os.access(resolved, os.X_OK):
+        raise ProfilePathVerificationError(f"binary is not executable: {resolved}")
+    return resolved
+
+
+def validate_results_path(results_path: Path) -> Path:
+    if not results_path.is_absolute():
+        raise ProfilePathVerificationError("results JSON path must be absolute")
+    absolute = Path(os.path.abspath(results_path))
+    if absolute.exists() and (absolute.is_dir() or absolute.is_symlink()):
+        raise ProfilePathVerificationError(
+            f"results JSON must be a regular file path: {absolute}"
+        )
+    return absolute
+
+
+def prepare_work_dir(work_dir: Path, results_path: Path) -> Path:
+    if not work_dir.is_absolute():
+        raise ProfilePathVerificationError("work directory path must be absolute")
+    _reject_mnt_path(work_dir, "work directory")
+    absolute = Path(os.path.abspath(work_dir))
+    if absolute == Path("/") or absolute == Path("/tmp"):
+        raise ProfilePathVerificationError(
+            f"work directory must be a dedicated child directory: {absolute}"
+        )
+    if absolute.exists():
+        if absolute.is_symlink() or not absolute.is_dir():
+            raise ProfilePathVerificationError(
+                f"work directory must be a real directory: {absolute}"
+            )
+        entries = list(absolute.iterdir())
+        if entries:
+            raise ProfilePathVerificationError(
+                f"work directory must be empty: {absolute}"
+            )
+    else:
+        try:
+            absolute.mkdir(parents=True, mode=0o700)
+        except OSError as exc:
+            raise ProfilePathVerificationError(
+                f"could not create work directory {absolute}: {exc}"
+            ) from exc
+    if results_path == absolute:
+        raise ProfilePathVerificationError(
+            "results JSON path cannot be the work directory"
+        )
+    return absolute.resolve(strict=True)
+
+
+def validate_timeout(timeout: float) -> float:
+    if not 0.1 <= timeout <= MAX_TIMEOUT_SECONDS:
+        raise ProfilePathVerificationError(
+            f"timeout must be between 0.1 and {MAX_TIMEOUT_SECONDS:g} seconds"
+        )
+    return timeout
+
+
+def write_json(path: Path, value: Any) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.parent / f".{path.name}.{os.getpid()}.tmp"
+        with temporary.open("w", encoding="utf-8", newline="\n") as stream:
+            json.dump(value, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        os.replace(temporary, path)
+    except OSError as exc:
+        raise ProfilePathVerificationError(
+            f"could not write JSON {path}: {exc}"
+        ) from exc
+
+
+def snapshot_tree(root: Path) -> dict[str, Any]:
+    if not root.exists():
+        return {"exists": False, "entries": []}
+
+    entries: list[dict[str, Any]] = []
+    for current, directories, files in os.walk(root, followlinks=False):
+        directories.sort()
+        files.sort()
+        current_path = Path(current)
+        for name in (*directories, *files):
+            path = current_path / name
+            relative = path.relative_to(root).as_posix()
+            try:
+                metadata = path.lstat()
+            except OSError as exc:
+                entries.append({"path": relative, "type": "error", "error": str(exc)})
+                continue
+            entry: dict[str, Any] = {
+                "path": relative,
+                "mode": stat.S_IMODE(metadata.st_mode),
+            }
+            if stat.S_ISLNK(metadata.st_mode):
+                entry["type"] = "symlink"
+                try:
+                    entry["target"] = os.readlink(path)
+                except OSError as exc:
+                    entry["error"] = str(exc)
+            elif stat.S_ISDIR(metadata.st_mode):
+                entry["type"] = "directory"
+            elif stat.S_ISREG(metadata.st_mode):
+                entry["type"] = "file"
+                entry["size"] = metadata.st_size
+            else:
+                entry["type"] = "other"
+            entries.append(entry)
+    entries.sort(key=lambda entry: entry["path"])
+    return {"exists": True, "entries": entries}
+
+
+def _xdg_base(
+    case_root: Path, home: Path, kind: str, mode: str
+) -> tuple[Path, str | None]:
+    if mode == "default":
+        return home / f".{kind}", None
+    if mode == "custom":
+        path = case_root / f"xdg-{kind}"
+        return path, str(path)
+    if mode == "relative":
+        return home / f".{kind}", f"relative-{kind}"
+    raise ProfilePathVerificationError(f"unsupported {kind} mode: {mode}")
+
+
+def prepare_case(work_dir: Path, spec: CaseSpec) -> CaseContext:
+    root = work_dir / "state" / spec.name
+    evidence_root = work_dir / "evidence" / spec.name
+    home = root / "home"
+    temporary = root / "tmp"
+    runtime = root / "runtime"
+    for directory in (home, temporary, runtime):
+        directory.mkdir(parents=True, mode=0o700)
+    evidence_root.mkdir(parents=True)
+    runtime.chmod(0o700)
+
+    config_base, config_env = _xdg_base(root, home, "config", spec.config_mode)
+    cache_base, cache_env = _xdg_base(root, home, "cache", spec.cache_mode)
+
+    protected_paths: list[Path] = []
+    if spec.legacy_marker:
+        (home / ".floorp").mkdir()
+    if spec.floorp_marker:
+        marker = home / "Floorp"
+        marker.mkdir()
+        protected_paths.append(marker)
+    if spec.mozilla_marker:
+        marker = home / "mozilla"
+        marker.mkdir()
+        protected_paths.append(marker)
+    if spec.precreate_xdg_product:
+        marker = config_base / "floorp"
+        marker.mkdir(parents=True)
+        protected_paths.append(marker)
+
+    expected_config_root = (
+        home / ".floorp"
+        if spec.legacy_marker or spec.force_legacy
+        else config_base / "floorp"
+    )
+    expected_cache_root = cache_base / "floorp"
+    profile_name = f"floorp2601-{spec.name}"
+
+    environment = {
+        "HOME": str(home),
+        "TMPDIR": str(temporary),
+        "XDG_RUNTIME_DIR": str(runtime),
+        "MOZ_HEADLESS": "1",
+        "MOZ_CRASHREPORTER_DISABLE": "1",
+        "MOZ_CRASHREPORTER_NO_REPORT": "1",
+        "NO_AT_BRIDGE": "1",
+    }
+    if config_env is not None:
+        environment["XDG_CONFIG_HOME"] = config_env
+    if cache_env is not None:
+        environment["XDG_CACHE_HOME"] = cache_env
+    if spec.force_legacy:
+        environment["MOZ_LEGACY_HOME"] = "1"
+
+    protected_before = {
+        str(path.relative_to(root)): snapshot_tree(path) for path in protected_paths
+    }
+    return CaseContext(
+        spec=spec,
+        root=root,
+        evidence_root=evidence_root,
+        home=home,
+        config_base=config_base,
+        cache_base=cache_base,
+        expected_config_root=expected_config_root,
+        expected_cache_root=expected_cache_root,
+        profile_name=profile_name,
+        environment=environment,
+        protected_paths=tuple(protected_paths),
+        protected_before=protected_before,
+    )
+
+
+def _clean_environment(case_environment: dict[str, str]) -> dict[str, str]:
+    environment = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+    }
+    environment.update(case_environment)
+    return environment
+
+
+def _signal_process_group(process_group: int, process_signal: signal.Signals) -> bool:
+    try:
+        os.killpg(process_group, process_signal)
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return False
+
+
+def _terminate_process_group(process_group: int) -> None:
+    if not _signal_process_group(process_group, signal.SIGTERM):
+        return
+    time.sleep(0.25)
+    _signal_process_group(process_group, signal.SIGKILL)
+
+
+def launch_create_profile(
+    binary: Path,
+    context: CaseContext,
+    stdout_path: Path,
+    stderr_path: Path,
+    timeout: float,
+) -> dict[str, Any]:
+    command = [
+        str(binary),
+        "--headless",
+        "--no-remote",
+        "--createprofile",
+        context.profile_name,
+    ]
+    started = time.monotonic()
+    timed_out = False
+    return_code: int | None = None
+    process: subprocess.Popen[bytes] | None = None
+    try:
+        with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+            process = subprocess.Popen(
+                command,
+                cwd=context.root,
+                env=_clean_environment(context.environment),
+                stdin=subprocess.DEVNULL,
+                stdout=stdout,
+                stderr=stderr,
+                start_new_session=True,
+            )
+            try:
+                return_code = process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                _terminate_process_group(process.pid)
+                try:
+                    return_code = process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    _signal_process_group(process.pid, signal.SIGKILL)
+                    return_code = process.wait(timeout=5)
+            else:
+                _terminate_process_group(process.pid)
+    except OSError as exc:
+        if process is not None and process.poll() is None:
+            _terminate_process_group(process.pid)
+        raise ProfilePathVerificationError(f"could not launch Floorp: {exc}") from exc
+
+    return {
+        "command": command,
+        "return_code": return_code,
+        "timed_out": timed_out,
+        "duration_seconds": round(time.monotonic() - started, 3),
+    }
+
+
+def _contains_bytes(path: Path, needle: bytes) -> bool:
+    try:
+        overlap = b""
+        with path.open("rb") as stream:
+            while chunk := stream.read(64 * 1024):
+                combined = overlap + chunk
+                if needle in combined:
+                    return True
+                overlap = combined[-(len(needle) - 1) :] if len(needle) > 1 else b""
+    except OSError as exc:
+        raise ProfilePathVerificationError(
+            f"could not read process log {path}: {exc}"
+        ) from exc
+    return False
+
+
+def parse_created_profile(context: CaseContext) -> dict[str, str]:
+    profiles_ini = context.expected_config_root / "profiles.ini"
+    parser = configparser.ConfigParser(
+        interpolation=None,
+        strict=True,
+        empty_lines_in_values=False,
+    )
+    parser.optionxform = str
+    try:
+        with profiles_ini.open("r", encoding="utf-8-sig") as stream:
+            parser.read_file(stream, source=str(profiles_ini))
+    except (OSError, UnicodeError, configparser.Error) as exc:
+        raise ProfilePathVerificationError(
+            f"could not parse expected profiles.ini {profiles_ini}: {exc}"
+        ) from exc
+
+    sections = [
+        section
+        for section in parser.sections()
+        if PROFILE_SECTION_RE.fullmatch(section)
+    ]
+    if len(sections) != 1:
+        raise ProfilePathVerificationError(
+            f"expected exactly one profile entry in {profiles_ini}, found {len(sections)}"
+        )
+    section = sections[0]
+    try:
+        name = parser.get(section, "Name", raw=True)
+        is_relative = parser.get(section, "IsRelative", raw=True)
+        raw_path = parser.get(section, "Path", raw=True)
+    except (configparser.NoOptionError, configparser.NoSectionError) as exc:
+        raise ProfilePathVerificationError(
+            f"incomplete [{section}] in {profiles_ini}: {exc}"
+        ) from exc
+
+    if name != context.profile_name:
+        raise ProfilePathVerificationError(
+            f"profile name mismatch: expected {context.profile_name}, got {name}"
+        )
+    if is_relative != "1":
+        raise ProfilePathVerificationError(
+            f"profile path must be relative, got IsRelative={is_relative!r}"
+        )
+
+    relative = PurePosixPath(raw_path)
+    if (
+        relative.is_absolute()
+        or len(relative.parts) != 1
+        or relative.parts[0] in ("", ".", "..")
+    ):
+        raise ProfilePathVerificationError(
+            f"profile Path must be one direct child, got {raw_path!r}"
+        )
+    profile_child = relative.parts[0]
+    config_profile = context.expected_config_root / profile_child
+    cache_profile = context.expected_cache_root / profile_child
+    if not config_profile.is_dir():
+        raise ProfilePathVerificationError(
+            f"configuration profile child is missing: {config_profile}"
+        )
+    if not cache_profile.is_dir():
+        raise ProfilePathVerificationError(
+            f"matching cache profile child is missing: {cache_profile}"
+        )
+
+    return {
+        "section": section,
+        "name": name,
+        "relative_path": profile_child,
+        "config_profile": str(config_profile),
+        "cache_profile": str(cache_profile),
+    }
+
+
+def assert_case_invariants(context: CaseContext) -> dict[str, str]:
+    capital_floorp = context.home / "Floorp"
+    if context.spec.floorp_marker:
+        before = context.protected_before[str(capital_floorp.relative_to(context.root))]
+        if snapshot_tree(capital_floorp) != before:
+            raise ProfilePathVerificationError("pre-existing ~/Floorp was modified")
+    elif capital_floorp.exists():
+        raise ProfilePathVerificationError("unexpected ~/Floorp was created")
+
+    legacy_floorp = context.home / ".floorp"
+    if context.expected_config_root != legacy_floorp and legacy_floorp.exists():
+        raise ProfilePathVerificationError(
+            "unexpected ~/.floorp was created for an XDG profile"
+        )
+
+    for protected in context.protected_paths:
+        key = str(protected.relative_to(context.root))
+        if protected == capital_floorp:
+            continue
+        if snapshot_tree(protected) != context.protected_before[key]:
+            raise ProfilePathVerificationError(
+                f"ignored or losing path was modified: {protected}"
+            )
+
+    for base in (context.config_base, context.cache_base):
+        dotted_sibling = base / ".floorp"
+        if dotted_sibling.exists():
+            raise ProfilePathVerificationError(
+                f"unexpected dotted Floorp sibling under XDG base: {dotted_sibling}"
+            )
+        capital_sibling = base / "Floorp"
+        if capital_sibling.exists():
+            raise ProfilePathVerificationError(
+                f"unexpected capitalized Floorp sibling under XDG base: "
+                f"{capital_sibling}"
+            )
+
+    candidates = {
+        context.home / ".floorp" / "profiles.ini",
+        context.config_base / "floorp" / "profiles.ini",
+    }
+    expected_ini = context.expected_config_root / "profiles.ini"
+    for candidate in candidates - {expected_ini}:
+        if candidate.exists():
+            raise ProfilePathVerificationError(
+                f"profiles.ini was created in a losing root: {candidate}"
+            )
+
+    return parse_created_profile(context)
+
+
+def preserve_profiles_ini(context: CaseContext, destination: Path) -> None:
+    sources = sorted(context.root.rglob("profiles.ini"))
+    if len(sources) > 16:
+        raise ProfilePathVerificationError(
+            f"found too many profiles.ini files to preserve: {len(sources)}"
+        )
+    files: list[dict[str, Any]] = []
+    for source in sources:
+        if source.is_symlink() or not source.is_file():
+            raise ProfilePathVerificationError(
+                f"profiles.ini evidence source is not a regular file: {source}"
+            )
+        try:
+            data = source.read_bytes()
+        except OSError as exc:
+            raise ProfilePathVerificationError(
+                f"could not preserve profiles.ini from {source}: {exc}"
+            ) from exc
+        if len(data) > 1024 * 1024:
+            raise ProfilePathVerificationError(
+                f"profiles.ini exceeds 1 MiB and was not copied: {source}"
+            )
+        try:
+            content = data.decode("utf-8-sig", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise ProfilePathVerificationError(
+                f"profiles.ini is not valid UTF-8: {source}"
+            ) from exc
+        files.append({
+            "path": source.relative_to(context.root).as_posix(),
+            "size": len(data),
+            "content": content,
+        })
+    write_json(destination, {"files": files})
+
+
+def run_case(
+    binary: Path, work_dir: Path, spec: CaseSpec, timeout: float
+) -> dict[str, Any]:
+    context = prepare_case(work_dir, spec)
+    stdout_path = context.evidence_root / "stdout.txt"
+    stderr_path = context.evidence_root / "stderr.txt"
+    profiles_ini_path = context.evidence_root / "profiles-ini.json"
+    before_path = context.evidence_root / "tree-before.json"
+    after_path = context.evidence_root / "tree-after.json"
+    case_result_path = context.evidence_root / "result.json"
+    write_json(before_path, snapshot_tree(context.root))
+
+    result: dict[str, Any] = {
+        "name": spec.name,
+        "status": "failed",
+        "profile_name": context.profile_name,
+        "environment": {
+            key: context.environment[key]
+            for key in (
+                "HOME",
+                "TMPDIR",
+                "XDG_RUNTIME_DIR",
+                "XDG_CONFIG_HOME",
+                "XDG_CACHE_HOME",
+                "MOZ_LEGACY_HOME",
+                "MOZ_HEADLESS",
+            )
+            if key in context.environment
+        },
+        "expected": {
+            "config_root": str(context.expected_config_root),
+            "cache_root": str(context.expected_cache_root),
+        },
+        "artifacts": {
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+            "profiles_ini": str(profiles_ini_path),
+            "tree_before": str(before_path),
+            "tree_after": str(after_path),
+            "result": str(case_result_path),
+        },
+        "errors": [],
+    }
+
+    errors: list[str] = result["errors"]
+    try:
+        process_result = launch_create_profile(
+            binary, context, stdout_path, stderr_path, timeout
+        )
+        result["process"] = process_result
+        if process_result["timed_out"]:
+            errors.append(f"Floorp exceeded the {timeout:g} second timeout")
+        if process_result["return_code"] != 0:
+            errors.append(f"Floorp exited with code {process_result['return_code']}")
+        if _contains_bytes(stdout_path, CREATE_PROFILE_ERROR) or _contains_bytes(
+            stderr_path, CREATE_PROFILE_ERROR
+        ):
+            errors.append("Floorp reported 'Error creating profile.'")
+        if not errors:
+            try:
+                result["profile"] = assert_case_invariants(context)
+            except ProfilePathVerificationError as exc:
+                errors.append(str(exc))
+    except ProfilePathVerificationError as exc:
+        errors.append(str(exc))
+    finally:
+        try:
+            preserve_profiles_ini(context, profiles_ini_path)
+        except ProfilePathVerificationError as exc:
+            errors.append(str(exc))
+        write_json(after_path, snapshot_tree(context.root))
+
+    if not errors:
+        result["status"] = "passed"
+    write_json(case_result_path, result)
+    return result
+
+
+def run_verification(
+    binary: Path,
+    work_dir: Path,
+    results_path: Path,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    if platform.system() != "Linux":
+        raise ProfilePathVerificationError("Linux is required")
+    validated_results = validate_results_path(results_path)
+    validated_binary = validate_binary(binary)
+    validated_timeout = validate_timeout(timeout)
+    validated_work = prepare_work_dir(work_dir, validated_results)
+
+    started_at = utc_now()
+    case_results = [
+        run_case(validated_binary, validated_work, spec, validated_timeout)
+        for spec in CASES
+    ]
+    passed = sum(result["status"] == "passed" for result in case_results)
+    summary = {
+        "schema_version": 1,
+        "status": "passed" if passed == len(CASES) else "failed",
+        "success": passed == len(CASES),
+        "started_at": started_at,
+        "finished_at": utc_now(),
+        "binary": str(validated_binary),
+        "work_dir": str(validated_work),
+        "timeout_seconds": validated_timeout,
+        "counts": {
+            "total": len(CASES),
+            "passed": passed,
+            "failed": len(CASES) - passed,
+        },
+        "cases": case_results,
+    }
+    write_json(validated_results, summary)
+    return summary
+
+
+def _write_fatal_result(results_path: Path, message: str) -> None:
+    try:
+        if results_path.is_absolute():
+            write_json(
+                Path(os.path.abspath(results_path)),
+                {
+                    "schema_version": 1,
+                    "status": "fatal",
+                    "success": False,
+                    "finished_at": utc_now(),
+                    "fatal_error": message,
+                },
+            )
+    except ProfilePathVerificationError:
+        pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify packaged Floorp Linux profile and cache paths"
+    )
+    parser.add_argument("--binary", required=True, type=Path)
+    parser.add_argument("--work-dir", required=True, type=Path)
+    parser.add_argument("--results-json", required=True, type=Path)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    args = parser.parse_args(argv)
+
+    try:
+        summary = run_verification(
+            args.binary, args.work_dir, args.results_json, args.timeout
+        )
+    except ProfilePathVerificationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        _write_fatal_result(args.results_json, str(exc))
+        return 2
+
+    print(
+        "Floorp Linux profile path verification: "
+        f"{summary['counts']['passed']}/{summary['counts']['total']} passed; "
+        f"results={args.results_json}"
+    )
+    if not summary["success"]:
+        for result in summary["cases"]:
+            if result["status"] != "passed":
+                print(
+                    f"error: {result['name']}: {'; '.join(result['errors'])}",
+                    file=sys.stderr,
+                )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/verify-runtime-artifact.yml
+++ b/.github/workflows/verify-runtime-artifact.yml
@@ -233,11 +233,13 @@ jobs:
               core.setFailed("selected source artifact is expired");
             }
 
-      - name: Checkout native identity parser
+      - name: Checkout native verification scripts
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          sparse-checkout: .github/workflows/scripts/verify_full_version.py
+          sparse-checkout: |
+            .github/workflows/scripts/verify_full_version.py
+            .github/workflows/scripts/verify_linux_profile_paths.py
           sparse-checkout-cone-mode: false
 
       - name: Set up Python
@@ -341,6 +343,9 @@ jobs:
           EXPECTED_BUILD_ID: ${{ inputs.expected-build-id }}
           OUTPUT_FILE: ${{ runner.temp }}/native-full-version.txt
           PARSER_PATH: ${{ github.workspace }}/.github/workflows/scripts/verify_full_version.py
+          PROFILE_PATH_VERIFIER: ${{ github.workspace }}/.github/workflows/scripts/verify_linux_profile_paths.py
+          PROFILE_PATH_WORK_DIR: ${{ runner.temp }}/floorp-profile-path-verification
+          PROFILE_PATH_RESULTS: ${{ runner.temp }}/floorp-profile-path-results.json
           TARGET_ARCH: ${{ inputs.arch }}
         run: |
           set -euo pipefail
@@ -384,6 +389,22 @@ jobs:
           python "$PARSER_PATH" \
             --expected-build-id "$EXPECTED_BUILD_ID" \
             --output-file "$OUTPUT_FILE"
+          python "$PROFILE_PATH_VERIFIER" \
+            --binary "${binaries[0]}" \
+            --work-dir "$PROFILE_PATH_WORK_DIR" \
+            --results-json "$PROFILE_PATH_RESULTS"
+
+      - name: Upload Linux profile path verification evidence
+        if: always() && inputs.platform == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-profile-path-verification-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/floorp-profile-path-results.json
+            ${{ runner.temp }}/floorp-profile-path-verification/evidence
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 14
 
       - name: Verify macOS universal final runtime natively
         if: inputs.platform == 'Darwin'


### PR DESCRIPTION
Fixes Floorp-Projects/Floorp#2601

## Summary

- recognize the official `Ablaze / Floorp / Floorp` app identity in the GTK profile-path logic
- place fresh Floorp configuration and cache data under the XDG `floorp` roots
- preserve existing `~/.floorp` profiles and `MOZ_LEGACY_HOME=1` behavior
- ignore `~/Floorp` and `~/mozilla` as legacy markers for official Floorp
- add focused Gecko GTests and a packaged-runtime `--createprofile` verifier
- run the packaged verifier from `verify-runtime-artifact.yml` and retain its evidence

## Root cause

Firefox's XDG implementation intentionally keeps applications with a non-null `gAppData->profile` on the named-profile path. Floorp sets `Profile=Floorp`, so the generic path first created `~/Floorp`, then interpreted it as a legacy marker, and selected `~/.floorp` instead of the XDG configuration root.

The patch narrows the exception to the official Floorp identity. Other branded applications, including Noraneko, keep the generic upstream behavior.

## Local validation

- full Linux runtime build: passed
- focused Floorp GTests: 13/13 passed
- upstream app-data fixture controls: 6/6 + 6/6 passed
- packaged Floorp profile-path smoke: 8/8 passed
- pre-fix packaged baseline with the same verifier: 1/8 passed, 7/8 failed
- verifier unit tests: 11/11 passed
- Ruff check and format check: passed
- workflow YAML parse: passed
- all 25 upstream patches applied cleanly in a fresh source tree
- applied C++ sources passed diff checking and clang-format

## GitHub-hosted validation

All runs below used PR head `f21a838d54b98669b3f9d4aebfca7f49558981f4`.

- [Linux x86_64 build](https://github.com/Floorp-Projects/Floorp-Runtime/actions/runs/30733757675): passed
- [Linux aarch64 build](https://github.com/Floorp-Projects/Floorp-Runtime/actions/runs/30733758875): passed and produced the aarch64 artifact
- [Linux x86_64 final-runtime verification](https://github.com/Floorp-Projects/Floorp-Runtime/actions/runs/30738129928): native `--full-version` identity matched BuildID `20260802051405`; profile-path smoke 8/8 passed; evidence artifact retained
- [Linux aarch64 final-runtime verification](https://github.com/Floorp-Projects/Floorp-Runtime/actions/runs/30738138388): native `--full-version` identity matched BuildID `20260802051408`; profile-path smoke 8/8 passed; evidence artifact retained

The repository currently reports no automatic `pull_request` status checks for this PR, so these validations were run explicitly through the repository workflows against the exact PR head.
