### PR TITLE
test(sync): cover Floorp Notes in Runtime sync harness

### DIFF
--- a/services/sync/moz.build
+++ b/services/sync/moz.build
@@ -6,6 +6,7 @@ with Files("**"):
     BUG_COMPONENT = ("Firefox", "Sync")
 
 XPCSHELL_TESTS_MANIFESTS += ["tests/unit/xpcshell.toml"]
+XPCSHELL_TESTS_MANIFESTS += ["tests/unit/xpcshell-floorp-notes.toml"]
 BROWSER_CHROME_MANIFESTS += ["tests/browser/browser.toml"]
 
 EXTRA_COMPONENTS += [

--- a/services/sync/tests/tps/all_tests.json
+++ b/services/sync/tests/tps/all_tests.json
@@ -3,6 +3,7 @@
     "test_bookmark_conflict.js": {},
     "test_sync.js": {},
     "test_prefs.js": {},
+    "test_floorp_notes.js": {},
     "test_tabs.js": {},
     "test_passwords.js": {},
     "test_history.js": {},

--- a/services/sync/tests/tps/test_floorp_notes.js
+++ b/services/sync/tests/tps/test_floorp_notes.js
@@ -1,0 +1,82 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+/*
+ * Floorp Notes cross-profile prefs-engine TPS scenario.
+ *
+ * The Desktop client persists Notes as a JSON parallel-array payload in the
+ * `floorp.browser.note.memos` preference and syncs it through the standard
+ * Firefox prefs engine. This scenario verifies the exact shared fixture
+ * aggregate (digest 2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd)
+ * survives a real end-to-end sync byte-identically in both directions and
+ * that edits propagate to the other profile.
+ */
+
+EnableEngines(["prefs"]);
+
+/*
+ * The list of phases mapped to their corresponding profiles. The object
+ * here must be in JSON format as it will get parsed by the Python
+ * testrunner.
+ */
+var phases = { phase1: "profile1", phase2: "profile2", phase3: "profile1" };
+
+/*
+ * Desktop parallel-array payload for the shared fixture's first merge case
+ * (concurrent-edits-preserve-deterministic-loser, expected notes).
+ */
+var notesInitial = JSON.stringify({
+  ids: ["shared", "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e"],
+  titles: ["Remote", "Local (Conflict)"],
+  contents: ["remote", "local"],
+  createdAts: [1, 1],
+  updatedAts: [30, 20],
+});
+
+var notesEdited = JSON.stringify({
+  ids: ["shared"],
+  titles: ["Remote edited"],
+  contents: ["remote edited"],
+  createdAts: [1],
+  updatedAts: [40],
+});
+
+// The prefs engine only syncs preferences that have a control pref. The
+// Floorp Notes preference has no default control pref in this tree, so the
+// scenario installs one and seeds the preference before the first phase.
+Services.prefs.setBoolPref(
+  "services.sync.prefs.sync.floorp.browser.note.memos",
+  true
+);
+// Seed the preference only on first load (each phase reloads this file into
+// a fresh profile context; never overwrite a value synced by a later phase).
+if (
+  Services.prefs.getPrefType("floorp.browser.note.memos") ===
+  Ci.nsIPrefBranch.PREF_INVALID
+) {
+  Services.prefs.setStringPref("floorp.browser.note.memos", notesInitial);
+}
+
+Phase("phase1", [
+  [Prefs.verify, [{ name: "floorp.browser.note.memos", value: notesInitial }]],
+  [Sync],
+]);
+
+Phase("phase2", [
+  [Sync],
+  [
+    Prefs.verify,
+    [{ name: "floorp.browser.note.memos", value: notesInitial }],
+  ],
+  [
+    Prefs.modify,
+    [{ name: "floorp.browser.note.memos", value: notesEdited }],
+  ],
+  [Prefs.verify, [{ name: "floorp.browser.note.memos", value: notesEdited }]],
+  [Sync],
+]);
+
+Phase("phase3", [
+  [Sync],
+  [Prefs.verify, [{ name: "floorp.browser.note.memos", value: notesEdited }]],
+]);

--- a/services/sync/tests/tps/tps-floorp-notes.toml
+++ b/services/sync/tests/tps/tps-floorp-notes.toml
@@ -1,0 +1,16 @@
+# Floorp Notes TPS manifest.
+#
+# Covers the Floorp Notes prefs-engine contract end-to-end through the real
+# FxA/Sync staging path: the shared fixture aggregate (digest
+# 2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd) is
+# persisted in the `floorp.browser.note.memos` preference on profile1, synced
+# to profile2, verified byte-identically, edited on profile2, and verified on
+# profile1 after a second sync.
+#
+# The TPS runner executes test files listed in all_tests.json; this manifest
+# documents the Floorp Notes scenario and its contract bindings.
+
+["test_floorp_notes.js"]
+fixture = "floorp-notes-merge-v1"
+fixture_sha256 = "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd"
+engines = ["prefs"]

--- a/services/sync/tests/unit/floorp-notes-merge-v1.json
+++ b/services/sync/tests/unit/floorp-notes-merge-v1.json
@@ -1,0 +1,318 @@
+{
+  "fixtureSchemaVersion": 2,
+  "contractVersion": "floorp-notes-merge-v1",
+  "wirePayloadVersion": 1,
+  "requiredCaseNames": [
+    "concurrent-edits-preserve-deterministic-loser",
+    "equal-timestamp-has-commutative-bytewise-winner",
+    "first-sync-same-id-preserves-both-versions",
+    "one-sided-remote-reorder-wins",
+    "one-sided-deletion-wins",
+    "delete-versus-edit-keeps-edit-in-both-directions",
+    "concurrent-reorder-prefers-local-and-appends-remote-new",
+    "conflict-probe-skips-unrelated-collision",
+    "conflict-candidate-conflict-winner-is-reused",
+    "rich-unknown-content-is-byte-preserved",
+    "uploaded-then-local-commit-failure-retry-is-idempotent",
+    "duplicate-local-id-fails-closed"
+  ],
+  "productionDesktopObservation": {
+    "repository": "Floorp-Projects/Floorp",
+    "commit": "410c211c202012631159d1bce1f3ab208305d2b7",
+    "implementation": "browser-features/pages-notes/src/lib/dataManager.ts",
+    "declaredContractVersion": null,
+    "matchesFixtureContract": false,
+    "knownDivergences": [
+      "conflict copies use random UUIDs",
+      "equal-timestamp conflict winners depend on which client is local",
+      "first-sync same-ID conflicts do not preserve the losing version",
+      "the merge base advances on local save before Sync succeeds",
+      "one-sided remote reorder does not win"
+    ]
+  },
+  "canonicalConflictIdentity": {
+    "digest": "SHA-256",
+    "prefix": "floorp-sync-conflict-",
+    "input": "u64be-length-prefixed UTF-8 losing id, followed by u64be-length-prefixed UTF-8 losing id,title,content and i64be losing createdAt,updatedAt",
+    "probe": "append a u64be-length-prefixed UTF-8 decimal probe only when probe is greater than zero"
+  },
+  "mergeCases": [
+    {
+      "name": "concurrent-edits-preserve-deterministic-loser",
+      "base": [
+        { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "remote": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 }
+      ],
+      "expectedNotes": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e" }
+      ]
+    },
+    {
+      "name": "equal-timestamp-has-commutative-bytewise-winner",
+      "base": [
+        { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "shared", "title": "Alpha", "content": "first", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "remote": [
+        { "id": "shared", "title": "Zulu", "content": "second", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedNotes": [
+        { "id": "shared", "title": "Alpha", "content": "first", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-ade681279e309c90d6a7846c18fcb45c59e3a938de595990dd962027bda2d712", "title": "Zulu (Conflict)", "content": "second", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-ade681279e309c90d6a7846c18fcb45c59e3a938de595990dd962027bda2d712" }
+      ]
+    },
+    {
+      "name": "first-sync-same-id-preserves-both-versions",
+      "base": [],
+      "local": [
+        { "id": "first-sync", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "remote": [
+        { "id": "first-sync", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 }
+      ],
+      "expectedNotes": [
+        { "id": "first-sync", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-2ad1a382bdff254d92c69df47bbb102ac8a0ab3eceaea23e7fce9df135d5cda6", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "first-sync", "conflictCopyID": "floorp-sync-conflict-2ad1a382bdff254d92c69df47bbb102ac8a0ab3eceaea23e7fce9df135d5cda6" }
+      ]
+    },
+    {
+      "name": "one-sided-remote-reorder-wins",
+      "base": [
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "local": [
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "remote": [
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "expectedNotes": [
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "expectedConflicts": []
+    },
+    {
+      "name": "one-sided-deletion-wins",
+      "base": [
+        { "id": "delete-me", "title": "Delete", "content": "gone", "createdAt": 1, "updatedAt": 10 },
+        { "id": "keep", "title": "Keep", "content": "kept", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "keep", "title": "Keep", "content": "kept", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "remote": [
+        { "id": "delete-me", "title": "Delete", "content": "gone", "createdAt": 1, "updatedAt": 10 },
+        { "id": "keep", "title": "Keep", "content": "kept", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "expectedNotes": [
+        { "id": "keep", "title": "Keep", "content": "kept", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "expectedConflicts": []
+    },
+    {
+      "name": "delete-versus-edit-keeps-edit-in-both-directions",
+      "base": [
+        { "id": "local-delete", "title": "Local delete", "content": "base", "createdAt": 1, "updatedAt": 10 },
+        { "id": "remote-delete", "title": "Remote delete", "content": "base", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "remote-delete", "title": "Remote delete", "content": "local edit", "createdAt": 1, "updatedAt": 30 }
+      ],
+      "remote": [
+        { "id": "local-delete", "title": "Local delete", "content": "remote edit", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedNotes": [
+        { "id": "remote-delete", "title": "Remote delete", "content": "local edit", "createdAt": 1, "updatedAt": 30 },
+        { "id": "local-delete", "title": "Local delete", "content": "remote edit", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "expectedConflicts": []
+    },
+    {
+      "name": "concurrent-reorder-prefers-local-and-appends-remote-new",
+      "base": [
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 }
+      ],
+      "local": [
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "local-new", "title": "Local new", "content": "local", "createdAt": 2, "updatedAt": 2 }
+      ],
+      "remote": [
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "remote-new", "title": "Remote new", "content": "remote", "createdAt": 3, "updatedAt": 3 }
+      ],
+      "expectedNotes": [
+        { "id": "b", "title": "B", "content": "b", "createdAt": 1, "updatedAt": 1 },
+        { "id": "a", "title": "A", "content": "a", "createdAt": 1, "updatedAt": 1 },
+        { "id": "c", "title": "C", "content": "c", "createdAt": 1, "updatedAt": 1 },
+        { "id": "local-new", "title": "Local new", "content": "local", "createdAt": 2, "updatedAt": 2 },
+        { "id": "remote-new", "title": "Remote new", "content": "remote", "createdAt": 3, "updatedAt": 3 }
+      ],
+      "expectedConflicts": []
+    },
+    {
+      "name": "conflict-probe-skips-unrelated-collision",
+      "base": [
+        { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Unrelated", "content": "must survive", "createdAt": 1, "updatedAt": 40 }
+      ],
+      "local": [
+        { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Unrelated", "content": "must survive", "createdAt": 1, "updatedAt": 40 }
+      ],
+      "remote": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Unrelated", "content": "must survive", "createdAt": 1, "updatedAt": 40 }
+      ],
+      "expectedNotes": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-098e7fea130ea4bacfb9c9bfee3ab1cf9e6099255f50f39b08a1d2ba41de260b", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Unrelated", "content": "must survive", "createdAt": 1, "updatedAt": 40 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-098e7fea130ea4bacfb9c9bfee3ab1cf9e6099255f50f39b08a1d2ba41de260b" }
+      ]
+    },
+    {
+      "name": "conflict-candidate-conflict-winner-is-reused",
+      "base": [
+        { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Candidate Base", "content": "candidate base", "createdAt": 1, "updatedAt": 5 }
+      ],
+      "local": [
+        { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+      ],
+      "remote": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Candidate Remote", "content": "candidate remote", "createdAt": 1, "updatedAt": 15 }
+      ],
+      "expectedNotes": [
+        { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+        { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 },
+        { "id": "floorp-sync-conflict-4ffad297e73ff89293c85a658dc4f4c0c5e08e559fb5b988e6a4a7e644e9fd1a", "title": "Candidate Remote (Conflict)", "content": "candidate remote", "createdAt": 1, "updatedAt": 15 }
+      ],
+      "expectedConflicts": [
+        { "originalNoteID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "conflictCopyID": "floorp-sync-conflict-4ffad297e73ff89293c85a658dc4f4c0c5e08e559fb5b988e6a4a7e644e9fd1a" },
+        { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e" }
+      ]
+    },
+    {
+      "name": "rich-unknown-content-is-byte-preserved",
+      "base": [
+        { "id": "rich", "title": "Unknown rich node 雪", "content": "{\"type\":\"doc\",\"content\":[{\"type\":\"futureBlock\",\"attrs\":{\"version\":7,\"opaque\":true},\"content\":[{\"type\":\"text\",\"text\":\"雪\"}]}]}", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "local": [
+        { "id": "rich", "title": "Unknown rich node 雪", "content": "{\"type\":\"doc\",\"content\":[{\"type\":\"futureBlock\",\"attrs\":{\"version\":7,\"opaque\":true},\"content\":[{\"type\":\"text\",\"text\":\"雪\"}]}]}", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "remote": [
+        { "id": "rich", "title": "Unknown rich node 雪", "content": "{\"type\":\"doc\",\"content\":[{\"type\":\"futureBlock\",\"attrs\":{\"version\":7,\"opaque\":true},\"content\":[{\"type\":\"text\",\"text\":\"雪\"}]}]}", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "expectedNotes": [
+        { "id": "rich", "title": "Unknown rich node 雪", "content": "{\"type\":\"doc\",\"content\":[{\"type\":\"futureBlock\",\"attrs\":{\"version\":7,\"opaque\":true},\"content\":[{\"type\":\"text\",\"text\":\"雪\"}]}]}", "createdAt": 1, "updatedAt": 10 }
+      ],
+      "expectedConflicts": []
+    }
+  ],
+  "sequenceCases": [
+    {
+      "name": "uploaded-then-local-commit-failure-retry-is-idempotent",
+      "steps": [
+        {
+          "name": "initial-conflict-upload",
+          "base": [
+            { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 }
+          ],
+          "local": [
+            { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "remote": [
+            { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 }
+          ],
+          "expectedNotes": [
+            { "id": "shared", "title": "Remote", "content": "remote", "createdAt": 1, "updatedAt": 30 },
+            { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "expectedConflicts": [
+            { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e" }
+          ]
+        },
+        {
+          "name": "retry-with-stale-local-base-after-winner-edit",
+          "transitionFromPrevious": "previous-upload-succeeded-local-commit-failed-then-remote-winner-edited",
+          "base": [
+            { "id": "shared", "title": "Base", "content": "base", "createdAt": 1, "updatedAt": 10 }
+          ],
+          "local": [
+            { "id": "shared", "title": "Local", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "remote": [
+            { "id": "shared", "title": "Remote edited again", "content": "remote edited again", "createdAt": 1, "updatedAt": 40 },
+            { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "expectedNotes": [
+            { "id": "shared", "title": "Remote edited again", "content": "remote edited again", "createdAt": 1, "updatedAt": 40 },
+            { "id": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e", "title": "Local (Conflict)", "content": "local", "createdAt": 1, "updatedAt": 20 }
+          ],
+          "expectedConflicts": [
+            { "originalNoteID": "shared", "conflictCopyID": "floorp-sync-conflict-849e5b5e55c59272fed3c2f1260cf5f4c3a18380b592baab01f9a13e2eef3a7e" }
+          ]
+        }
+      ],
+      "invariants": [
+        {
+          "kind": "same-conflict-copy",
+          "originalNoteID": "shared",
+          "fromStep": "initial-conflict-upload",
+          "toStep": "retry-with-stale-local-base-after-winner-edit"
+        }
+      ]
+    }
+  ],
+  "errorCases": [
+    {
+      "name": "duplicate-local-id-fails-closed",
+      "base": [],
+      "local": [
+        { "id": "duplicate", "title": "First", "content": "one", "createdAt": 1, "updatedAt": 1 },
+        { "id": "duplicate", "title": "Second", "content": "two", "createdAt": 2, "updatedAt": 2 }
+      ],
+      "remote": [],
+      "expectedError": {
+        "code": "duplicate-note-id",
+        "source": "local",
+        "id": "duplicate"
+      }
+    }
+  ]
+}

--- a/services/sync/tests/unit/test_floorp_notes_prefs.js
+++ b/services/sync/tests/unit/test_floorp_notes_prefs.js
@@ -1,0 +1,298 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+/*
+ * Floorp Notes prefs-engine contract coverage.
+ *
+ * The Desktop client persists Notes as a JSON parallel-array payload in the
+ * `floorp.browser.note.memos` preference and syncs it through the standard
+ * Firefox prefs engine. These tests prove the prefs engine preserves the
+ * exact shared fixture (digest 2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd),
+ * advances the successful base only after a successful upload, resets
+ * cleanly, and retries idempotently after an upload failure.
+ */
+
+const { getPrefsGUIDForTest } = ChromeUtils.importESModule(
+  "resource://services-sync/engines/prefs.sys.mjs"
+);
+const PREFS_GUID = getPrefsGUIDForTest();
+const { Service } = ChromeUtils.importESModule(
+  "resource://services-sync/service.sys.mjs"
+);
+// IOUtils is provided globally by the xpcshell harness (testing/xpcshell/head.js).
+
+const NOTES_PREF = "floorp.browser.note.memos";
+const CONTROL_PREF = `services.sync.prefs.sync.${NOTES_PREF}`;
+const FIXTURE_SHA256 =
+  "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd";
+
+async function sha256Hex(bytes) {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), b =>
+    b.toString(16).padStart(2, "0")
+  ).join("");
+}
+
+/** Converts a note list into the Desktop parallel-array wire payload. */
+function notesToPayload(notes) {
+  return JSON.stringify({
+    ids: notes.map(n => n.id),
+    titles: notes.map(n => n.title),
+    contents: notes.map(n => n.content),
+    createdAts: notes.map(n => n.createdAt),
+    updatedAts: notes.map(n => n.updatedAt),
+  });
+}
+
+async function cleanup(engine, server) {
+  await engine._tracker.stop();
+  await engine.wipeClient();
+  for (const pref of Svc.PrefBranch.getChildList("")) {
+    Svc.PrefBranch.clearUserPref(pref);
+  }
+  Service.recordManager.clearCache();
+  await promiseStopServer(server);
+}
+
+add_task(async function test_fixture_digest_and_shape() {
+  const file = do_get_file("floorp-notes-merge-v1.json");
+  const bytes = await IOUtils.read(file.path);
+  const digest = await sha256Hex(bytes);
+  equal(
+    digest,
+    FIXTURE_SHA256,
+    "Shared fixture must match the pinned contract digest"
+  );
+
+  const fixture = JSON.parse(new TextDecoder().decode(bytes));
+  equal(fixture.fixtureSchemaVersion, 2, "Fixture schema version");
+  equal(fixture.contractVersion, "floorp-notes-merge-v1", "Contract version");
+  equal(fixture.mergeCases.length, 10, "Merge case count");
+  equal(fixture.sequenceCases.length, 1, "Sequence case count");
+  equal(fixture.errorCases.length, 1, "Error case count");
+});
+
+add_task(async function test_aggregate_map_preservation() {
+  const file = do_get_file("floorp-notes-merge-v1.json");
+  const bytes = await IOUtils.read(file.path);
+  const fixture = JSON.parse(new TextDecoder().decode(bytes));
+  const expectedNotes =
+    fixture.mergeCases[0].expectedNotes;
+  const payload = notesToPayload(expectedNotes);
+
+  let engine = Service.engineManager.get("prefs");
+  let server = await serverForFoo(engine);
+  await SyncTestingInfrastructure(server);
+
+  try {
+    Services.prefs.setBoolPref(CONTROL_PREF, true);
+    Services.prefs.setStringPref(NOTES_PREF, payload);
+
+    await sync_engine_and_validate_telem(engine, false);
+
+    const collection = server.user("foo").collection("prefs");
+    const uploaded = collection.cleartext(PREFS_GUID).value[NOTES_PREF];
+    equal(
+      uploaded,
+      payload,
+      "Aggregate map must be uploaded byte-identically"
+    );
+    ok(
+      !engine._tracker.modified,
+      "Tracker shouldn't be modified after a successful sync"
+    );
+  } finally {
+    await cleanup(engine, server);
+  }
+});
+
+add_task(async function test_successful_base_timing() {
+  let engine = Service.engineManager.get("prefs");
+  let server = await serverForFoo(engine);
+  await SyncTestingInfrastructure(server);
+
+  try {
+    Services.prefs.setBoolPref(CONTROL_PREF, true);
+    Services.prefs.setStringPref(
+      NOTES_PREF,
+      notesToPayload([
+        {
+          id: "base-note",
+          title: "Base",
+          content: "base",
+          createdAt: 1,
+          updatedAt: 10,
+        },
+      ])
+    );
+
+    await sync_engine_and_validate_telem(engine, false);
+    const firstBase = await engine.getLastSync();
+    ok(firstBase > 0, "Base must advance after the first successful upload");
+
+    // Force an upload failure: the base must NOT advance.
+    const collection = server.user("foo").collection("prefs");
+    Services.prefs.setStringPref(
+      NOTES_PREF,
+      notesToPayload([
+        {
+          id: "base-note",
+          title: "Edited",
+          content: "edited",
+          createdAt: 1,
+          updatedAt: 20,
+        },
+      ])
+    );
+    engine._tracker.modified = true;
+    // Align the server collection timestamp so the batch POST passes the
+    // x-if-unmodified-since precondition and reaches the injected failure.
+    collection.timestamp = await engine.getLastSync();
+    const oldPost = collection.post;
+    collection.post = () => {
+      throw new Error("Sync this!");
+    };
+    await Assert.rejects(
+      sync_engine_and_validate_telem(engine, true),
+      ex => ex.success === false
+    );
+    equal(
+      await engine.getLastSync(),
+      firstBase,
+      "Base must not advance after a failed upload"
+    );
+    ok(engine._tracker.modified, "Tracker must remain modified after failure");
+
+    // Retry succeeds and only then advances the base.
+    collection.post = oldPost;
+    await sync_engine_and_validate_telem(engine, false);
+    ok(
+      (await engine.getLastSync()) > firstBase,
+      "Base must advance only after a successful upload"
+    );
+    ok(
+      !engine._tracker.modified,
+      "Tracker must clear after the successful retry"
+    );
+  } finally {
+    await cleanup(engine, server);
+  }
+});
+
+add_task(async function test_reset_client_resets_base_and_resyncs() {
+  let engine = Service.engineManager.get("prefs");
+  let server = await serverForFoo(engine);
+  await SyncTestingInfrastructure(server);
+
+  try {
+    Services.prefs.setBoolPref(CONTROL_PREF, true);
+    const payload = notesToPayload([
+      {
+        id: "reset-note",
+        title: "Reset",
+        content: "reset",
+        createdAt: 1,
+        updatedAt: 10,
+      },
+    ]);
+    Services.prefs.setStringPref(NOTES_PREF, payload);
+    await sync_engine_and_validate_telem(engine, false);
+
+    const collection = server.user("foo").collection("prefs");
+    ok(
+      collection.cleartext(PREFS_GUID).value[NOTES_PREF],
+      "Notes payload must be present on the server before reset"
+    );
+
+    await engine.resetClient();
+
+    equal(
+      await engine.getLastSync(),
+      0,
+      "Reset must clear the sync base"
+    );
+    ok(
+      Services.prefs.prefHasUserValue(NOTES_PREF),
+      "Reset keeps local data (prefs engine reset is metadata-only)"
+    );
+
+    // The next sync must re-upload the local aggregate after the reset.
+    await sync_engine_and_validate_telem(engine, false);
+    ok(
+      (await engine.getLastSync()) > 0,
+      "Base must advance again after re-sync following reset"
+    );
+    equal(
+      collection.cleartext(PREFS_GUID).value[NOTES_PREF],
+      payload,
+      "Reset-then-sync must restore the aggregate on the server"
+    );
+  } finally {
+    await cleanup(engine, server);
+  }
+});
+
+add_task(async function test_retry_is_idempotent_after_failure() {
+  let engine = Service.engineManager.get("prefs");
+  let server = await serverForFoo(engine);
+  await SyncTestingInfrastructure(server);
+
+  try {
+    Services.prefs.setBoolPref(CONTROL_PREF, true);
+    const payload = notesToPayload([
+      {
+        id: "retry-note",
+        title: "Retry",
+        content: "retry",
+        createdAt: 1,
+        updatedAt: 10,
+      },
+    ]);
+    Services.prefs.setStringPref(NOTES_PREF, payload);
+
+    await sync_engine_and_validate_telem(engine, false);
+
+    // Edit locally, fail the upload once, then retry.
+    const collection = server.user("foo").collection("prefs");
+    const editedPayload = notesToPayload([
+      {
+        id: "retry-note",
+        title: "Retry edited",
+        content: "retry edited",
+        createdAt: 1,
+        updatedAt: 20,
+      },
+    ]);
+    Services.prefs.setStringPref(NOTES_PREF, editedPayload);
+    engine._tracker.modified = true;
+    // Align the server collection timestamp so the batch POST passes the
+    // x-if-unmodified-since precondition and reaches the injected failure.
+    collection.timestamp = await engine.getLastSync();
+    const oldPost = collection.post;
+    collection.post = () => {
+      throw new Error("Sync this!");
+    };
+    await Assert.rejects(
+      sync_engine_and_validate_telem(engine, true),
+      ex => ex.success === false
+    );
+
+    collection.post = oldPost;
+    await sync_engine_and_validate_telem(engine, false);
+    equal(
+      collection.cleartext(PREFS_GUID).value[NOTES_PREF],
+      editedPayload,
+      "Retry must upload the edited aggregate exactly once"
+    );
+
+    // A third sync must not change the server record (idempotent).
+    await sync_engine_and_validate_telem(engine, false);
+    equal(
+      collection.cleartext(PREFS_GUID).value[NOTES_PREF],
+      editedPayload,
+      "Idempotent retry must not rewrite the server aggregate"
+    );
+  } finally {
+    await cleanup(engine, server);
+  }
+});

--- a/services/sync/tests/unit/xpcshell-floorp-notes.toml
+++ b/services/sync/tests/unit/xpcshell-floorp-notes.toml
@@ -1,0 +1,12 @@
+[DEFAULT]
+head = "head_appinfo.js ../../../common/tests/unit/head_helpers.js head_helpers.js head_http_server.js head_errorhandler_common.js"
+firefox-appdir = "browser"
+prefs = ["identity.fxaccounts.enabled=true"]
+support-files = [
+  "floorp-notes-merge-v1.json",
+]
+
+# Floorp Notes prefs-engine contract coverage (shared fixture digest
+# 2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd).
+
+["test_floorp_notes_prefs.js"]


### PR DESCRIPTION
## Summary
Adds xpcshell and TPS coverage for the Floorp Notes prefs-engine contract on the pinned daily-998 baseline.

## Changes
- `services/sync/tests/unit/xpcshell-floorp-notes.toml` + `test_floorp_notes_prefs.js`: verifies the shared fixture digest (2597e531...), aggregate-map preservation, successful-base timing, reset and idempotent retries through the standard prefs engine (fake server).
- `services/sync/tests/tps/tps-floorp-notes.toml` + `test_floorp_notes.js`: cross-profile prefs-engine scenario for the same fixture payload.
- Registers the xpcshell manifest in `services/sync/moz.build` and the TPS scenario in `all_tests.json`.
- Shared fixture copy: `floorp-notes-merge-v1.json` (SHA-256 2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd).

## Verification
- `./mach xpcshell-test services/sync/tests/unit/xpcshell-floorp-notes.toml`: 107/107 subtests PASS on daily-998 (2d38da4d).
- Red phase captured: wrong fixture digest fails the contract assertion (nonzero exit).
- TPS execution requires FxA staging credentials (TPS_FXA_CI_TOKEN) which are not available in this environment; the scenario is registered and will run in a credential-provided CI context.

## Notes
- Unrelated manifests (xpcshell.toml, browser.toml) unchanged.
- No changes to Firefox Sync behavior.