### PR TITLE
Harden TPS production Sync validation

### DIFF
--- a/services/sync/tests/tps/tps-floorp-notes.toml
+++ b/services/sync/tests/tps/tps-floorp-notes.toml
@@ -1,14 +1,16 @@
 # Floorp Notes TPS manifest.
 #
 # Covers the Floorp Notes prefs-engine contract end-to-end through the real
-# FxA/Sync staging path: the shared fixture aggregate (digest
+# FxA/Sync path selected by the TPS runner: the shared fixture aggregate (digest
 # 2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd) is
 # persisted in the `floorp.browser.note.memos` preference on profile1, synced
 # to profile2, verified byte-identically, edited on profile2, and verified on
 # profile1 after a second sync.
 #
 # The TPS runner executes test files listed in all_tests.json; this manifest
-# documents the Floorp Notes scenario and its contract bindings.
+# documents the Floorp Notes scenario and its contract bindings. Floorp's
+# production gate uses only a dedicated QA account supplied interactively or
+# through masked environment credentials.
 
 ["test_floorp_notes.js"]
 fixture = "floorp-notes-merge-v1"

--- a/services/sync/tps/extensions/tps/resource/actors/fxaAutofillChild.sys.mjs
+++ b/services/sync/tps/extensions/tps/resource/actors/fxaAutofillChild.sys.mjs
@@ -13,6 +13,7 @@ export class TPSFxAAutofillChild extends JSWindowActorChild {
     this._password = "";
     this._timerId = 0;
     this._lastSubmit = 0;
+    this._submittedSteps = new Set();
   }
 
   didDestroy() {
@@ -65,7 +66,7 @@ export class TPSFxAAutofillChild extends JSWindowActorChild {
       return false;
     }
     const win = this.contentWindow;
-    console.warn(`[TPS Autofill] Filling ${input.name} with value)`);
+    console.warn(`[TPS Autofill] Filling ${input.name} with value`);
     input.focus();
     input.value = value;
     input.dispatchEvent(new win.Event("input", { bubbles: true }));
@@ -73,6 +74,15 @@ export class TPSFxAAutofillChild extends JSWindowActorChild {
     input.dispatchEvent(new win.Event("blur", { bubbles: true }));
     console.warn(`[TPS Autofill] Field ${input.name} filled`);
     return true;
+  }
+
+  _isUsableInput(input) {
+    return (
+      input &&
+      !input.disabled &&
+      input.type !== "hidden" &&
+      input.getAttribute?.("aria-hidden") !== "true"
+    );
   }
 
   _fillAndSubmit() {
@@ -83,17 +93,24 @@ export class TPSFxAAutofillChild extends JSWindowActorChild {
     const passwordInput = doc.querySelector(
       'input[name="password"], input[type="password"]'
     );
-    const submitButton = doc.querySelector(
-      'button[type="submit"]:not([disabled]), button:not([type]):not([disabled])'
-    );
-
-    if (!submitButton) {
+    const emailUsable = this._isUsableInput(emailInput);
+    const passwordUsable = this._isUsableInput(passwordInput);
+    let activeStep = "";
+    if (passwordUsable) {
+      activeStep = "password";
+    } else if (emailUsable) {
+      activeStep = "email";
+    }
+    if (!activeStep) {
       return false;
+    }
+    if (this._submittedSteps.has(activeStep)) {
+      return activeStep === "password";
     }
 
     // Fill email if present
     let emailFilled = false;
-    if (emailInput && emailInput.offsetParent !== null) {
+    if (emailUsable) {
       this._setInputValue(emailInput, this._email);
       emailFilled = emailInput.value.trim() === this._email.trim();
       console.warn(
@@ -103,7 +120,7 @@ export class TPSFxAAutofillChild extends JSWindowActorChild {
 
     // Fill password if present
     let passwordFilled = false;
-    if (passwordInput && passwordInput.offsetParent !== null) {
+    if (passwordUsable) {
       this._setInputValue(passwordInput, this._password);
       passwordFilled = passwordInput.value === this._password;
       console.warn(
@@ -122,6 +139,21 @@ export class TPSFxAAutofillChild extends JSWindowActorChild {
       return false;
     }
 
+    // Scope submission to the active input's form. The password page also has
+    // an enabled password-recovery button, which must never be selected as the
+    // generic first button in the document.
+    const activeInput = passwordFilled ? passwordInput : emailInput;
+    const form = activeInput?.form || activeInput?.closest?.("form");
+    if (!form) {
+      return false;
+    }
+    const submitSelector =
+      'button[type="submit"]:not([disabled]), input[type="submit"]:not([disabled])';
+    const submitButton = form.querySelector(submitSelector);
+    if (!submitButton) {
+      return false;
+    }
+
     // Wait a bit for the button to become enabled after input
     // Don't click too fast (debounce)
     const now = Date.now();
@@ -134,11 +166,15 @@ export class TPSFxAAutofillChild extends JSWindowActorChild {
     try {
       submitButton.click();
       console.warn("[TPS Autofill] Clicked submit button");
+      this._submittedSteps.add(activeStep);
     } catch (e) {
       console.error("[TPS Autofill] Failed to click button:", e);
       return false;
     }
 
-    return true;
+    // The production FxA flow presents email and password as separate steps in
+    // the same document. Keep polling after the email step and stop only after
+    // the password step has been submitted.
+    return activeStep === "password";
   }
 }

--- a/services/sync/tps/extensions/tps/resource/auth/fxaccounts.sys.mjs
+++ b/services/sync/tps/extensions/tps/resource/auth/fxaccounts.sys.mjs
@@ -19,19 +19,32 @@ const fxAccounts = getFxAccountsSingleton();
 const AUTOFILL_ACTOR_NAME = "TPSFxAAutofill";
 const FXA_HOSTS = new Set([
   "accounts.firefox.com",
+  "oauth.accounts.firefox.com",
   "accounts.stage.mozaws.net",
   "api-accounts.stage.mozaws.net",
   "api.accounts.firefox.com",
 ]);
+const FXA_STAGING_HOSTS = new Set([
+  "accounts.stage.mozaws.net",
+  "api-accounts.stage.mozaws.net",
+]);
 const BYPASS_TOKEN_PREF = "tps.fxa.bypassToken";
 const FXA_CI_HEADER = "fxa-ci";
 const OAUTH_READY_POLL_INTERVAL_MS = 1000;
-const OAUTH_TIMEOUT_MS = 120000;
+const OAUTH_TIMEOUT_PREF = "testing.tps.oauthTimeoutMs";
+const DEFAULT_OAUTH_TIMEOUT_MS = 120000;
 const RESTMAIL_POLL_INTERVAL_MS = 1000;
 const RESTMAIL_MAX_ATTEMPTS = 60;
 
 function getBypassToken() {
   return Services.prefs.getStringPref(BYPASS_TOKEN_PREF, "");
+}
+
+function getOAuthTimeoutMs() {
+  return Services.prefs.getIntPref(
+    OAUTH_TIMEOUT_PREF,
+    DEFAULT_OAUTH_TIMEOUT_MS
+  );
 }
 
 let gAutofillActorRegistered = false;
@@ -61,7 +74,7 @@ function ensureBypassHeaderObserverRegistered() {
         return;
       }
       const channel = subject.QueryInterface(Ci.nsIHttpChannel);
-      if (FXA_HOSTS.has(channel.URI.host)) {
+      if (FXA_STAGING_HOSTS.has(channel.URI.host)) {
         channel.setRequestHeader(FXA_CI_HEADER, token, false);
       }
     },
@@ -87,6 +100,7 @@ function ensureAutofillActorRegistered() {
       },
       matches: [
         "https://accounts.firefox.com/*",
+        "https://oauth.accounts.firefox.com/*",
         "https://accounts.stage.mozaws.net/*",
       ],
       messageManagerGroups: ["browsers"],
@@ -195,6 +209,7 @@ export var Authentication = {
 
   async _automateOAuthFlow(oauthUrl, email, password) {
     ensureAutofillActorRegistered();
+    const oauthTimeoutMs = getOAuthTimeoutMs();
 
     const win = Services.ww.openWindow(
       null,
@@ -307,6 +322,7 @@ export var Authentication = {
             );
             return;
           }
+          configureAutofillActor(browser?.currentURI?.spec || oauthUrl);
           if (await this.isReady()) {
             finish(resolve);
           }
@@ -321,10 +337,10 @@ export var Authentication = {
         finish(
           reject,
           new Error(
-            `OAuth flow timed out after ${OAUTH_TIMEOUT_MS / 1000} seconds`
+            `OAuth flow timed out after ${oauthTimeoutMs / 1000} seconds`
           )
         );
-      }, OAUTH_TIMEOUT_MS);
+      }, oauthTimeoutMs);
 
       if (
         win.document.readyState === "complete" ||
@@ -415,7 +431,7 @@ export var Authentication = {
   async signIn(account) {
     Logger.AssertTrue(account.username, "Username has been found");
     Logger.AssertTrue(account.password, "Password has been found");
-    Logger.logInfo("Login user: " + account.username);
+    Logger.logInfo("Login user configured");
 
     try {
       await FxAccountsConfig.ensureConfigured();

--- a/testing/moz.build
+++ b/testing/moz.build
@@ -14,6 +14,7 @@ with Files("remote*"):
 
 PYTHON_UNITTEST_MANIFESTS += [
     "test/python.toml",
+    "tps/python.toml",
 ]
 
 if not CONFIG["JS_STANDALONE"]:

--- a/testing/tps/README
+++ b/testing/tps/README
@@ -49,6 +49,20 @@ Options:
   --logfile         Path to log file (default: tps.log)
   --debug           Enable debug logging
 
+For an existing account, prefer the `TPS_FXA_USERNAME` and
+`TPS_FXA_PASSWORD` environment variables instead of command-line arguments.
+Both variables must be set together. The runner removes them from the Firefox
+child-process environment before launch.
+
+TPS uses an unsigned extension with privileged experiment APIs. Release and
+beta milestone builds require a separate test-only build with add-on signing
+disabled:
+
+  MOZ_REQUIRE_SIGNING= ./mach build
+
+The empty value disables the configure option. This setting is for the local
+TPS test binary only and must not be used for a distributed build.
+
 Run in headless mode with:
   MOZ_HEADLESS=1 ./mach tps-test --testfile ... --auto-account
 
@@ -79,12 +93,27 @@ Manual Account Setup (Alternative)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you prefer to use an existing account:
 
-  ./mach tps-test --testfile services/sync/tests/tps/test_sync.js \
-                  --username your-test@restmail.net \
-                  --password your-password
+  TPS_FXA_USERNAME=your-test@restmail.net \
+  TPS_FXA_PASSWORD=your-password \
+    ./mach tps-test --testfile services/sync/tests/tps/test_sync.js
 
 Note: The account must already exist. You can create accounts manually at
 https://accounts.stage.mozaws.net (for staging).
 
 Note: The staging server approach is recommended for testing to avoid using
 production infrastructure. Accounts must be verified before TPS can use them.
+Production runs require the environment variables above; credentials passed as
+command-line arguments are rejected so they are not exposed in process lists.
+
+Production Retry Safety
+~~~~~~~~~~~~~~~~~~~~~~~
+Each FxA email or password form step is submitted at most once per document.
+If a challenge or rate-limit page appears, stop the run instead of repeatedly
+submitting the same step.
+
+Each normal phase has a ten-minute overall deadline, including Firefox startup,
+Marionette connection, TPS add-on installation, and the test itself. OAuth may
+use at most five minutes of that budget. Remote cleanup runs only for profiles
+that completed at least one normal phase successfully; cleanup has a one-minute
+overall deadline and a 30-second OAuth limit. Local profile cleanup and the TPS
+HTTP server shutdown still run after failures.

--- a/testing/tps/mach_commands.py
+++ b/testing/tps/mach_commands.py
@@ -6,6 +6,7 @@
 import json
 import os
 import re
+import socket
 import sys
 import time
 
@@ -13,7 +14,11 @@ from mach.decorators import Command, CommandArgument
 from mozpack.copier import Jarrer
 from mozpack.files import FileFinder
 
-PHASE_TIMEOUT_SECONDS = 300
+PHASE_TIMEOUT_SECONDS = 600
+TPS_STARTUP_TIMEOUT_SECONDS = 30
+TPS_CLEANUP_TIMEOUT_SECONDS = 60
+TPS_OAUTH_TIMEOUT_MS = 300000
+TPS_PHASE_SHUTDOWN_MARGIN_SECONDS = 30
 TPS_ENV = {
     "MOZ_CRASHREPORTER_DISABLE": "1",
     "GNOME_DISABLE_CRASH_DIALOG": "1",
@@ -45,6 +50,10 @@ TPS_PREFERENCES = {
     "engine.bookmarks.repair.enabled": False,
     "extensions.experiments.enabled": True,
     "webextensions.storage.sync.kinto": False,
+    # Marionette's generic recommended prefs redirect FxA to a dummy host.
+    # TPS exercises real FxA/Sync endpoints, so preserve this profile's URLs.
+    "remote.prefs.recommended": False,
+    "testing.tps.oauthTimeoutMs": TPS_OAUTH_TIMEOUT_MS,
 }
 TPS_DEBUG_PREFERENCES = {
     "services.sync.log.appender.console": "Trace",
@@ -139,6 +148,77 @@ def _load_test_phases(testfile):
     return yaml.safe_load(phases_str)
 
 
+def _resolve_fxa_credentials(
+    username, password, environ, *, allow_argument_credentials=True
+):
+    env_username = environ.get("TPS_FXA_USERNAME")
+    env_password = environ.get("TPS_FXA_PASSWORD")
+    argument_credentials = bool(username or password)
+    environment_credentials = bool(env_username or env_password)
+
+    if argument_credentials and environment_credentials:
+        raise ValueError(
+            "FxA argument credentials and environment credentials must not be mixed"
+        )
+    if argument_credentials:
+        if not allow_argument_credentials:
+            raise ValueError(
+                "FxA production credentials must be supplied through the environment"
+            )
+        if not username or not password:
+            raise ValueError("--username and --password must both be set")
+        return username, password
+    if environment_credentials:
+        if not env_username or not env_password:
+            raise ValueError("TPS_FXA_USERNAME and TPS_FXA_PASSWORD must both be set")
+        return env_username, env_password
+    raise ValueError(
+        "Either --auto-account, --username with --password, or "
+        "TPS_FXA_USERNAME with TPS_FXA_PASSWORD is required"
+    )
+
+
+def _resolve_fxa_ci_token(environ, *, fxa_staging):
+    if not fxa_staging:
+        return None
+    return environ.get("TPS_FXA_CI_TOKEN")
+
+
+def _prepare_tps_preferences(config, *, fxa_ci_token, debug):
+    preferences = TPS_PREFERENCES.copy()
+    preferences["tps.config"] = json.dumps(config)
+    if fxa_ci_token:
+        preferences["tps.fxa.bypassToken"] = fxa_ci_token
+    if debug:
+        preferences.update(TPS_DEBUG_PREFERENCES)
+    return preferences
+
+
+def _prepare_tps_environment(environ, topsrcdir, *, platform_name=None):
+    env = environ.copy()
+    env.pop("TPS_FXA_USERNAME", None)
+    env.pop("TPS_FXA_PASSWORD", None)
+    env.pop("TPS_FXA_CI_TOKEN", None)
+    env.update(TPS_ENV)
+    if (platform_name or sys.platform) == "darwin":
+        env["MOZ_DEVELOPER_REPO_DIR"] = os.path.abspath(topsrcdir)
+    return env
+
+
+def _cleanup_tps_resources(profiles, addon_server):
+    succeeded = True
+    try:
+        for profile in profiles:
+            try:
+                profile.cleanup()
+            except Exception as error:
+                succeeded = False
+                print(f"ERROR: Failed to clean up TPS profile: {error}")
+    finally:
+        addon_server.stop()
+    return succeeded
+
+
 def _extract_phase_status(logfile, testname, phase_name):
     found_test = False
 
@@ -161,6 +241,183 @@ def _extract_phase_status(logfile, testname, phase_name):
                     return "FAIL", line.split("CROSSWEAVE ERROR: ")[1].strip()
 
     return None, None
+
+
+def _allocate_marionette_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_for_tps_startup(logfile, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if os.path.exists(logfile):
+            with open(logfile) as log:
+                if "Sync version:" in log.read():
+                    return True
+        time.sleep(0.1)
+    return False
+
+
+def _oauth_timeout_for_phase(phase_timeout):
+    if phase_timeout <= 0:
+        raise ValueError("TPS phase timeout must be greater than zero")
+    shutdown_margin = min(TPS_PHASE_SHUTDOWN_MARGIN_SECONDS, phase_timeout / 2)
+    available_ms = max(1, int((phase_timeout - shutdown_margin) * 1000))
+    return min(TPS_OAUTH_TIMEOUT_MS, available_ms)
+
+
+def _run_tps_phase(
+    profile,
+    current_testfile,
+    phase_name,
+    testname,
+    logfile,
+    binary,
+    env,
+    tps_xpi,
+    phase_timeout=PHASE_TIMEOUT_SECONDS,
+    startup_timeout=TPS_STARTUP_TIMEOUT_SECONDS,
+    marionette_port=None,
+    runner_cls=None,
+    marionette_cls=None,
+    addons_cls=None,
+    monotonic=time.monotonic,
+    startup_waiter=_wait_for_tps_startup,
+):
+    if runner_cls is None:
+        from mozrunner import FirefoxRunner
+
+        runner_cls = FirefoxRunner
+    if marionette_cls is None:
+        from marionette_driver.marionette import Marionette
+
+        marionette_cls = Marionette
+    if addons_cls is None:
+        from marionette_driver.addons import Addons
+
+        addons_cls = Addons
+
+    try:
+        oauth_timeout_ms = _oauth_timeout_for_phase(phase_timeout)
+    except ValueError as error:
+        return "FAIL", f"invalid TPS phase timeout: {error}"
+
+    deadline = monotonic() + phase_timeout
+
+    def remaining(stage):
+        seconds = deadline - monotonic()
+        if seconds <= 0:
+            raise TimeoutError(
+                f"TPS phase timed out after {phase_timeout} seconds during {stage}"
+            )
+        return seconds
+
+    port = marionette_port or _allocate_marionette_port()
+    profile.set_preferences({
+        "testing.tps.testFile": current_testfile,
+        "testing.tps.testPhase": phase_name,
+        "testing.tps.logFile": logfile,
+        "testing.tps.ignoreUnusedEngines": False,
+        "testing.tps.oauthTimeoutMs": oauth_timeout_ms,
+        "marionette.port": port,
+    })
+
+    runner = runner_cls(
+        binary=binary,
+        profile=profile,
+        env=env,
+        cmdargs=["-marionette", "-remote-allow-system-access"],
+        process_args=[],
+    )
+    marionette = None
+    try:
+        runner.start(timeout=remaining("Firefox startup"))
+        session_timeout = min(startup_timeout, remaining("Marionette startup"))
+        marionette = marionette_cls(
+            host="127.0.0.1",
+            port=port,
+            startup_timeout=session_timeout,
+            socket_timeout=remaining("Marionette connection"),
+        )
+        marionette.start_session(timeout=session_timeout)
+        install_timeout = remaining("TPS add-on installation")
+        marionette.socket_timeout = install_timeout
+        if getattr(marionette, "client", None) is not None:
+            marionette.client.socket_timeout = install_timeout
+        addon_id = addons_cls(marionette).install(tps_xpi, temp=True)
+        if addon_id != "tps@mozilla.org":
+            return "FAIL", f"temporary TPS add-on returned unexpected id: {addon_id}"
+        startup_wait_timeout = min(startup_timeout, remaining("TPS add-on startup"))
+        if not startup_waiter(logfile, startup_wait_timeout):
+            return "FAIL", (
+                f"TPS add-on did not start within {startup_wait_timeout:g} seconds"
+            )
+
+        process_wait_timeout = remaining("TPS process completion")
+        returncode = runner.wait(timeout=process_wait_timeout)
+        if returncode is None:
+            runner.stop()
+            return "FAIL", f"TPS phase timed out after {phase_timeout} seconds"
+        return _extract_phase_status(logfile, testname, phase_name)
+    except TimeoutError as error:
+        return "FAIL", str(error)
+    except Exception as error:
+        return "FAIL", f"phase execution failed: {error}"
+    finally:
+        if marionette is not None:
+            try:
+                marionette.delete_session()
+            except Exception:
+                pass
+        runner.stop()
+
+
+def _run_tps_cleanup_phases(
+    *,
+    profiles,
+    used_profiles,
+    successful_profiles,
+    current_testfile,
+    testname,
+    logfile,
+    binary,
+    env,
+    tps_xpi,
+    phase_runner=None,
+):
+    if phase_runner is None:
+        phase_runner = _run_tps_phase
+
+    cleanup_failed = False
+    print("Running cleanup phases...")
+    for profile_name in sorted(used_profiles):
+        if profile_name not in successful_profiles:
+            print(f"Cleanup: {profile_name} (skipped; no successful phase)")
+            continue
+
+        profile = profiles[profile_name]
+        cleanup_phase = f"cleanup-{profile_name}"
+        print(f"Cleanup: {profile_name}")
+        status, error_line = phase_runner(
+            profile,
+            current_testfile,
+            cleanup_phase,
+            testname,
+            logfile,
+            binary,
+            env,
+            tps_xpi,
+            phase_timeout=TPS_CLEANUP_TIMEOUT_SECONDS,
+        )
+        if status != "PASS":
+            cleanup_failed = True
+            if error_line:
+                print(f"   Cleanup ERROR: {error_line}")
+            print(f"   Cleanup FAIL (status: {status})")
+
+    return cleanup_failed
 
 
 @Command(
@@ -209,7 +466,6 @@ def run_tps(
 ):
     """Run TPS tests with a simple command-line interface."""
     from mozprofile import Profile
-    from mozrunner import FirefoxRunner
     from wptserve import server
 
     print("Starting TPS test runner...")
@@ -227,7 +483,7 @@ def run_tps(
         fxa_staging = True
 
     # FxA stage has a WAF that requires a bypass token for automation.
-    fxa_ci_token = os.environ.get("TPS_FXA_CI_TOKEN")
+    fxa_ci_token = _resolve_fxa_ci_token(os.environ, fxa_staging=fxa_staging)
     if fxa_staging and not fxa_ci_token:
         print(
             "ERROR: TPS_FXA_CI_TOKEN env var is required for FxA staging.\n"
@@ -242,11 +498,17 @@ def run_tps(
         username = f"tps-test-{secrets.token_hex(8)}@restmail.net"
         password = secrets.token_urlsafe(16)
         print(f"   Account credentials generated: {username}")
-    elif not username or not password:
-        print(
-            "ERROR: Either --auto-account or both --username and --password are required"
-        )
-        return 1
+    else:
+        try:
+            username, password = _resolve_fxa_credentials(
+                username,
+                password,
+                os.environ,
+                allow_argument_credentials=not fxa_production,
+            )
+        except ValueError as error:
+            print(f"ERROR: {error}")
+            return 1
 
     # Build TPS extension
     print("Building TPS extension...")
@@ -299,42 +561,21 @@ def run_tps(
     if fxa_staging:
         print("Using FxA staging server")
 
-    preferences = TPS_PREFERENCES.copy()
-    preferences["tps.config"] = json.dumps(config)
-    if fxa_ci_token:
-        preferences["tps.fxa.bypassToken"] = fxa_ci_token
+    preferences = _prepare_tps_preferences(
+        config, fxa_ci_token=fxa_ci_token, debug=debug
+    )
     if debug:
-        preferences.update(TPS_DEBUG_PREFERENCES)
         print("Debug logging enabled")
 
-    env = os.environ.copy()
-    env.update(TPS_ENV)
-
-    if sys.platform == "darwin":
-        env["MOZ_DEVELOPER_REPO_DIR"] = os.path.abspath(command_context.topsrcdir)
+    env = _prepare_tps_environment(os.environ, command_context.topsrcdir)
 
     addon_server = server.WebTestHttpd(port=4567, doc_root=testdir)
     addon_server.start()
 
-    def run_phase(profile, current_testfile, phase_name, testname):
-        profile.set_preferences({
-            "testing.tps.testFile": current_testfile,
-            "testing.tps.testPhase": phase_name,
-            "testing.tps.logFile": logfile,
-            "testing.tps.ignoreUnusedEngines": False,
-        })
-        runner = FirefoxRunner(
-            binary=binary,
-            profile=profile,
-            env=env,
-            process_args=[],
-        )
-        runner.start()
-        runner.wait(timeout=PHASE_TIMEOUT_SECONDS)
-        return _extract_phase_status(logfile, testname, phase_name)
-
     failed_tests = []
     passed_tests = []
+    all_profiles = []
+    profile_cleanup_failed = False
     try:
         for index, current_testfile in enumerate(testfiles, start=1):
             testname = os.path.basename(current_testfile)
@@ -363,60 +604,64 @@ def run_tps(
             test_preferences["tps.seconds_since_epoch"] = int(time.time())
 
             profiles = {}
+            used_profiles = set()
+            successful_profiles = set()
             phase_list = []
             for phase_name, profile_name in sorted(test_phases.items()):
                 if profile_name not in profiles:
-                    profiles[profile_name] = Profile(
-                        preferences=test_preferences.copy(), addons=[tps_xpi]
-                    )
-                phase_list.append((phase_name, profiles[profile_name]))
+                    profile = Profile(preferences=test_preferences.copy())
+                    profiles[profile_name] = profile
+                    all_profiles.append(profile)
+                phase_list.append((phase_name, profile_name, profiles[profile_name]))
 
             test_failed = False
-            for phase_name, profile in phase_list:
+            for phase_name, profile_name, profile in phase_list:
+                used_profiles.add(profile_name)
                 print(f"Phase: {phase_name}")
-                try:
-                    status, error_line = run_phase(
-                        profile, current_testfile, phase_name, testname
-                    )
-                except Exception as e:
-                    print(f"   FAIL (phase execution failed: {e})\n")
-                    test_failed = True
-                    break
+                status, error_line = _run_tps_phase(
+                    profile,
+                    current_testfile,
+                    phase_name,
+                    testname,
+                    logfile,
+                    binary,
+                    env,
+                    tps_xpi,
+                    phase_timeout=PHASE_TIMEOUT_SECONDS,
+                )
                 if error_line:
                     print(f"   ERROR: {error_line}")
 
                 if status == "PASS":
+                    successful_profiles.add(profile_name)
                     print("   PASS\n")
                 else:
                     print(f"   FAIL (status: {status})\n")
                     test_failed = True
                     break
 
-            print("Running cleanup phases...")
-            for profile_name, profile in profiles.items():
-                cleanup_phase = f"cleanup-{profile_name}"
-                print(f"Cleanup: {profile_name}")
-
-                try:
-                    status, error_line = run_phase(
-                        profile, current_testfile, cleanup_phase, testname
-                    )
-                except Exception as e:
-                    test_failed = True
-                    print(f"   Cleanup FAIL (execution failed: {e})")
-                    continue
-                if status != "PASS":
-                    test_failed = True
-                    if error_line:
-                        print(f"   Cleanup ERROR: {error_line}")
-                    print(f"   Cleanup FAIL (status: {status})")
+            if _run_tps_cleanup_phases(
+                profiles=profiles,
+                used_profiles=used_profiles,
+                successful_profiles=successful_profiles,
+                current_testfile=current_testfile,
+                testname=testname,
+                logfile=logfile,
+                binary=binary,
+                env=env,
+                tps_xpi=tps_xpi,
+            ):
+                test_failed = True
 
             if test_failed:
                 failed_tests.append(testname)
             else:
                 passed_tests.append(testname)
     finally:
-        addon_server.stop()
+        profile_cleanup_failed = not _cleanup_tps_resources(all_profiles, addon_server)
+
+    if profile_cleanup_failed:
+        failed_tests.append("profile cleanup")
 
     # Final results
     print("\n" + "=" * 50)

--- a/testing/tps/python.toml
+++ b/testing/tps/python.toml
@@ -1,0 +1,4 @@
+[DEFAULT]
+subsuite = "tps"
+
+["test_mach_commands.py"]

--- a/testing/tps/test_fxa_autofill_actor.js
+++ b/testing/tps/test_fxa_autofill_actor.js
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* global process, require */
+
+const fs = require("fs");
+const vm = require("vm");
+
+const sourcePath = process.argv[2];
+const source = fs
+  .readFileSync(sourcePath, "utf8")
+  .replace("export class TPSFxAAutofillChild", "class TPSFxAAutofillChild")
+  .concat("\nthis.TPSFxAAutofillChild = TPSFxAAutofillChild;\n");
+
+const context = {
+  JSWindowActorChild: class {},
+  console: { warn() {}, error() {} },
+};
+vm.createContext(context);
+vm.runInContext(source, context, { filename: sourcePath });
+
+function makeInput(name, type, onInput) {
+  return {
+    name,
+    type,
+    value: "",
+    // Headless Firefox may report null for the active FxA form field.
+    offsetParent: null,
+    focus() {},
+    dispatchEvent(event) {
+      if (event.type === "input") {
+        onInput();
+      }
+    },
+  };
+}
+
+function makeActor({
+  emailVisible,
+  passwordVisible,
+  initiallyDisabled,
+  enableOnInput = true,
+}) {
+  let clicks = 0;
+  let distractorClicks = 0;
+  const button = {
+    type: "submit",
+    disabled: initiallyDisabled,
+    click() {
+      clicks += 1;
+    },
+  };
+  const distractor = {
+    type: "submit",
+    disabled: false,
+    click() {
+      distractorClicks += 1;
+    },
+  };
+  const enable = () => {
+    if (enableOnInput) {
+      button.disabled = false;
+    }
+  };
+  const email = emailVisible ? makeInput("email", "email", enable) : null;
+  const password = passwordVisible
+    ? makeInput("password", "password", enable)
+    : null;
+  const form = {
+    querySelector(selector) {
+      if (selector.includes('button[type="submit"]')) {
+        return button.disabled ? null : button;
+      }
+      return null;
+    },
+  };
+  if (email) {
+    email.form = form;
+  }
+  if (password) {
+    password.form = form;
+  }
+  const doc = {
+    querySelector(selector) {
+      if (selector.includes('input[name="email"]')) {
+        return email;
+      }
+      if (selector.includes('input[name="password"]')) {
+        return password;
+      }
+      if (selector.includes("button")) {
+        // A password-recovery button appears before the true form submit.
+        return distractor;
+      }
+      return null;
+    },
+  };
+  const actor = new context.TPSFxAAutofillChild();
+  actor.contentWindow = {
+    document: doc,
+    Event: class {
+      constructor(type) {
+        this.type = type;
+      }
+    },
+  };
+  actor._email = "qa@example.test";
+  actor._password = "secret";
+  return {
+    actor,
+    email,
+    password,
+    clicks: () => clicks,
+    distractorClicks: () => distractorClicks,
+  };
+}
+
+const emailStep = makeActor({
+  emailVisible: true,
+  passwordVisible: false,
+  initiallyDisabled: true,
+});
+const emailDone = emailStep.actor._fillAndSubmit();
+if (emailStep.email.value !== "qa@example.test" || emailStep.clicks() !== 1) {
+  throw new Error(
+    "email step was not filled and submitted after enabling button"
+  );
+}
+if (emailStep.distractorClicks() !== 0) {
+  throw new Error("email step clicked a non-submit distractor");
+}
+if (emailDone !== false) {
+  throw new Error("email-only step must keep polling for the password step");
+}
+emailStep.actor._lastSubmit = 0;
+const emailRepeatDone = emailStep.actor._fillAndSubmit();
+if (emailStep.clicks() !== 1) {
+  throw new Error("email step must be submitted at most once per document");
+}
+if (emailRepeatDone !== false) {
+  throw new Error("submitted email step must keep polling for password");
+}
+
+const passwordStep = makeActor({
+  emailVisible: false,
+  passwordVisible: true,
+  initiallyDisabled: true,
+});
+const passwordDone = passwordStep.actor._fillAndSubmit();
+if (passwordStep.password.value !== "secret" || passwordStep.clicks() !== 1) {
+  throw new Error("password step was not filled and submitted");
+}
+if (passwordStep.distractorClicks() !== 0) {
+  throw new Error("password step clicked a password-recovery distractor");
+}
+if (passwordDone !== true) {
+  throw new Error("password step must stop polling after submission");
+}
+passwordStep.actor._lastSubmit = 0;
+const passwordRepeatDone = passwordStep.actor._fillAndSubmit();
+if (passwordStep.clicks() !== 1) {
+  throw new Error("password step must be submitted at most once per document");
+}
+if (passwordRepeatDone !== true) {
+  throw new Error("submitted password step must remain complete");
+}
+
+const disabledScopedSubmit = makeActor({
+  emailVisible: true,
+  passwordVisible: false,
+  initiallyDisabled: true,
+  enableOnInput: false,
+});
+const disabledDone = disabledScopedSubmit.actor._fillAndSubmit();
+if (
+  disabledScopedSubmit.clicks() !== 0 ||
+  disabledScopedSubmit.distractorClicks() !== 0
+) {
+  throw new Error(
+    "disabled scoped submit must not fall back to an out-of-form submit"
+  );
+}
+if (disabledDone !== false) {
+  throw new Error("disabled scoped submit must keep polling");
+}
+
+console.log("actor two-step form tests passed");

--- a/testing/tps/test_mach_commands.py
+++ b/testing/tps/test_mach_commands.py
@@ -1,0 +1,484 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from mach.registrar import Registrar
+
+if "testing" not in Registrar.categories:
+    Registrar.register_category("testing", "Testing", "Run tests", 60)
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), "mach_commands.py")
+SPEC = importlib.util.spec_from_file_location("tps_mach_commands", MODULE_PATH)
+TPS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(TPS)
+
+
+class FakeProfile:
+    def __init__(self):
+        self.preferences = []
+
+    def set_preferences(self, preferences):
+        self.preferences.append(preferences)
+
+
+class FakeRunner:
+    wait_result = 0
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.started = False
+        self.stop_calls = 0
+        type(self).instances.append(self)
+
+    def start(self, timeout=None):
+        self.started = True
+        self.start_timeout = timeout
+
+    def wait(self, timeout):
+        self.wait_timeout = timeout
+        return type(self).wait_result
+
+    def stop(self):
+        self.stop_calls += 1
+
+
+class FakeMarionette:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.started = False
+        self.deleted = False
+        type(self).instances.append(self)
+
+    def start_session(self, timeout):
+        self.started = True
+        self.start_timeout = timeout
+
+    def delete_session(self):
+        self.deleted = True
+
+
+class FakeAddons:
+    logfile = None
+    phase_status = None
+    installs = []
+
+    def __init__(self, marionette):
+        self.marionette = marionette
+
+    def install(self, path, temp):
+        type(self).installs.append((path, temp))
+        with open(type(self).logfile, "a") as log:
+            log.write("TPS INFO | Sync version: test\n")
+            if type(self).phase_status:
+                log.write(f"2026-01-01 test phase phase1: {type(self).phase_status}\n")
+        return "tps@mozilla.org"
+
+
+class RunTPSPhaseTests(unittest.TestCase):
+    def setUp(self):
+        FakeRunner.instances.clear()
+        FakeRunner.wait_result = 0
+        FakeMarionette.instances.clear()
+        FakeAddons.installs.clear()
+        FakeAddons.phase_status = None
+
+    def run_phase(self, logfile):
+        FakeAddons.logfile = logfile
+        with open(logfile, "w") as log:
+            log.write("Running test test_floorp_notes.js\n")
+        return TPS._run_tps_phase(
+            profile=FakeProfile(),
+            current_testfile="/tmp/test_floorp_notes.js",
+            phase_name="phase1",
+            testname="test_floorp_notes.js",
+            logfile=logfile,
+            binary="/tmp/firefox",
+            env={},
+            tps_xpi="/tmp/tps.xpi",
+            phase_timeout=17,
+            startup_timeout=3,
+            marionette_port=2828,
+            runner_cls=FakeRunner,
+            marionette_cls=FakeMarionette,
+            addons_cls=FakeAddons,
+        )
+
+    def test_installs_tps_as_temporary_addon_and_returns_phase_status(self):
+        FakeAddons.phase_status = "PASS"
+        with tempfile.TemporaryDirectory() as tempdir:
+            status, error = self.run_phase(os.path.join(tempdir, "tps.log"))
+
+        self.assertEqual((status, error), ("PASS", None))
+        self.assertEqual(FakeAddons.installs, [("/tmp/tps.xpi", True)])
+        runner = FakeRunner.instances[0]
+        self.assertIn("-marionette", runner.kwargs["cmdargs"])
+        self.assertIn("-remote-allow-system-access", runner.kwargs["cmdargs"])
+        self.assertTrue(FakeMarionette.instances[0].started)
+
+    def test_stops_runner_when_phase_wait_times_out(self):
+        FakeRunner.wait_result = None
+        with tempfile.TemporaryDirectory() as tempdir:
+            status, error = self.run_phase(os.path.join(tempdir, "tps.log"))
+
+        self.assertEqual(status, "FAIL")
+        self.assertIn("timed out after 17 seconds", error)
+        self.assertGreaterEqual(FakeRunner.instances[0].stop_calls, 1)
+
+    def test_rejects_nonpositive_timeout_before_starting_firefox(self):
+        status, error = TPS._run_tps_phase(
+            profile=FakeProfile(),
+            current_testfile="/tmp/test_floorp_notes.js",
+            phase_name="phase1",
+            testname="test_floorp_notes.js",
+            logfile="/tmp/tps.log",
+            binary="/tmp/firefox",
+            env={},
+            tps_xpi="/tmp/tps.xpi",
+            phase_timeout=0,
+            marionette_port=2828,
+            runner_cls=FakeRunner,
+            marionette_cls=FakeMarionette,
+            addons_cls=FakeAddons,
+        )
+
+        self.assertEqual(status, "FAIL")
+        self.assertIn("must be greater than zero", error)
+        self.assertEqual(FakeRunner.instances, [])
+
+    def test_phase_timeout_is_an_overall_deadline(self):
+        class FakeClock:
+            now = 0.0
+
+            def __call__(self):
+                return self.now
+
+        clock = FakeClock()
+
+        class BudgetRunner(FakeRunner):
+            def start(self, timeout=None):
+                super().start(timeout=timeout)
+                clock.now += 2
+
+        class BudgetMarionette(FakeMarionette):
+            def start_session(self, timeout):
+                super().start_session(timeout)
+                clock.now += 3
+
+        class BudgetAddons(FakeAddons):
+            def install(self, path, temp):
+                result = super().install(path, temp)
+                clock.now += 4
+                return result
+
+        def startup_waiter(_logfile, timeout):
+            self.assertLessEqual(timeout, 3)
+            clock.now += 1
+            return True
+
+        FakeAddons.phase_status = "PASS"
+        with tempfile.TemporaryDirectory() as tempdir:
+            logfile = os.path.join(tempdir, "tps.log")
+            FakeAddons.logfile = logfile
+            with open(logfile, "w") as log:
+                log.write("Running test test_floorp_notes.js\n")
+            status, error = TPS._run_tps_phase(
+                profile=FakeProfile(),
+                current_testfile="/tmp/test_floorp_notes.js",
+                phase_name="phase1",
+                testname="test_floorp_notes.js",
+                logfile=logfile,
+                binary="/tmp/firefox",
+                env={},
+                tps_xpi="/tmp/tps.xpi",
+                phase_timeout=12,
+                startup_timeout=5,
+                marionette_port=2828,
+                runner_cls=BudgetRunner,
+                marionette_cls=BudgetMarionette,
+                addons_cls=BudgetAddons,
+                monotonic=clock,
+                startup_waiter=startup_waiter,
+            )
+
+        self.assertEqual((status, error), ("PASS", None))
+        self.assertGreater(BudgetRunner.instances[0].start_timeout, 0)
+        self.assertLessEqual(BudgetRunner.instances[0].start_timeout, 12)
+        self.assertGreater(BudgetMarionette.instances[0].socket_timeout, 0)
+        self.assertLessEqual(BudgetMarionette.instances[0].socket_timeout, 7)
+        self.assertGreater(BudgetRunner.instances[0].wait_timeout, 0)
+        self.assertLessEqual(BudgetRunner.instances[0].wait_timeout, 2)
+
+    def test_deadline_exhausted_during_start_stops_before_marionette(self):
+        class FakeClock:
+            now = 0.0
+
+            def __call__(self):
+                return self.now
+
+        clock = FakeClock()
+
+        class SlowStartRunner(FakeRunner):
+            def start(self, timeout=None):
+                super().start(timeout=timeout)
+                clock.now = 6
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            logfile = os.path.join(tempdir, "tps.log")
+            with open(logfile, "w") as log:
+                log.write("Running test test_floorp_notes.js\n")
+            status, error = TPS._run_tps_phase(
+                profile=FakeProfile(),
+                current_testfile="/tmp/test_floorp_notes.js",
+                phase_name="phase1",
+                testname="test_floorp_notes.js",
+                logfile=logfile,
+                binary="/tmp/firefox",
+                env={},
+                tps_xpi="/tmp/tps.xpi",
+                phase_timeout=5,
+                startup_timeout=3,
+                marionette_port=2828,
+                runner_cls=SlowStartRunner,
+                marionette_cls=FakeMarionette,
+                addons_cls=FakeAddons,
+                monotonic=clock,
+            )
+
+        self.assertEqual(status, "FAIL")
+        self.assertIn("during Marionette startup", error)
+        self.assertEqual(FakeMarionette.instances, [])
+        self.assertGreaterEqual(SlowStartRunner.instances[0].stop_calls, 1)
+
+    def test_cleanup_phase_uses_short_oauth_timeout(self):
+        FakeAddons.phase_status = "PASS"
+        profile = FakeProfile()
+        with tempfile.TemporaryDirectory() as tempdir:
+            logfile = os.path.join(tempdir, "tps.log")
+            FakeAddons.logfile = logfile
+            with open(logfile, "w") as log:
+                log.write("Running test test_floorp_notes.js\n")
+            status, error = TPS._run_tps_phase(
+                profile=profile,
+                current_testfile="/tmp/test_floorp_notes.js",
+                phase_name="phase1",
+                testname="test_floorp_notes.js",
+                logfile=logfile,
+                binary="/tmp/firefox",
+                env={},
+                tps_xpi="/tmp/tps.xpi",
+                phase_timeout=TPS.TPS_CLEANUP_TIMEOUT_SECONDS,
+                startup_timeout=3,
+                marionette_port=2828,
+                runner_cls=FakeRunner,
+                marionette_cls=FakeMarionette,
+                addons_cls=FakeAddons,
+            )
+
+        self.assertEqual((status, error), ("PASS", None))
+        self.assertEqual(profile.preferences[-1]["testing.tps.oauthTimeoutMs"], 30000)
+
+
+class PhaseTimeoutPolicyTests(unittest.TestCase):
+    def test_oauth_timeout_reserves_phase_shutdown_margin(self):
+        self.assertEqual(TPS._oauth_timeout_for_phase(600), 300000)
+        self.assertEqual(TPS._oauth_timeout_for_phase(60), 30000)
+        for phase_timeout in (60, 300, 600):
+            self.assertLess(
+                TPS._oauth_timeout_for_phase(phase_timeout), phase_timeout * 1000
+            )
+
+
+class RemoteCleanupPhaseTests(unittest.TestCase):
+    def test_skips_remote_cleanup_without_a_successful_phase(self):
+        calls = []
+
+        def phase_runner(
+            profile,
+            current_testfile,
+            phase_name,
+            testname,
+            logfile,
+            binary,
+            env,
+            tps_xpi,
+            **kwargs,
+        ):
+            calls.append((profile, phase_name, kwargs["phase_timeout"]))
+            return "PASS", None
+
+        profiles = {"failed": FakeProfile(), "passed": FakeProfile()}
+        failed = TPS._run_tps_cleanup_phases(
+            profiles=profiles,
+            used_profiles={"failed", "passed"},
+            successful_profiles={"passed"},
+            current_testfile="/tmp/test_floorp_notes.js",
+            testname="test_floorp_notes.js",
+            logfile="/tmp/tps.log",
+            binary="/tmp/firefox",
+            env={},
+            tps_xpi="/tmp/tps.xpi",
+            phase_runner=phase_runner,
+        )
+
+        self.assertFalse(failed)
+        self.assertEqual(
+            calls,
+            [(profiles["passed"], "cleanup-passed", TPS.TPS_CLEANUP_TIMEOUT_SECONDS)],
+        )
+
+
+class ResolveCredentialsTests(unittest.TestCase):
+    def test_reads_complete_credentials_from_environment(self):
+        username, password = TPS._resolve_fxa_credentials(
+            None,
+            None,
+            {
+                "TPS_FXA_USERNAME": "qa@example.test",
+                "TPS_FXA_PASSWORD": "secret",
+            },
+        )
+
+        self.assertEqual(username, "qa@example.test")
+        self.assertEqual(password, "secret")
+
+    def test_rejects_partial_environment_credentials(self):
+        with self.assertRaisesRegex(ValueError, "must both be set"):
+            TPS._resolve_fxa_credentials(
+                None,
+                None,
+                {"TPS_FXA_USERNAME": "qa@example.test"},
+            )
+
+    def test_rejects_mixed_argument_and_environment_credentials(self):
+        with self.assertRaisesRegex(ValueError, "must not be mixed"):
+            TPS._resolve_fxa_credentials(
+                "qa@example.test",
+                "argument-secret",
+                {
+                    "TPS_FXA_USERNAME": "qa@example.test",
+                    "TPS_FXA_PASSWORD": "environment-secret",
+                },
+            )
+
+    def test_rejects_argument_credentials_for_production(self):
+        with self.assertRaisesRegex(ValueError, "production.*environment"):
+            TPS._resolve_fxa_credentials(
+                "qa@example.test",
+                "argument-secret",
+                {},
+                allow_argument_credentials=False,
+            )
+
+
+class ResolveFxaCiTokenTests(unittest.TestCase):
+    def test_returns_token_for_staging(self):
+        self.assertEqual(
+            TPS._resolve_fxa_ci_token(
+                {"TPS_FXA_CI_TOKEN": "stage-token"}, fxa_staging=True
+            ),
+            "stage-token",
+        )
+
+    def test_discards_token_for_production(self):
+        self.assertIsNone(
+            TPS._resolve_fxa_ci_token(
+                {"TPS_FXA_CI_TOKEN": "stage-token"}, fxa_staging=False
+            )
+        )
+
+
+class ProductionBoundaryTests(unittest.TestCase):
+    def test_disables_webdriver_recommended_offline_preferences(self):
+        self.assertFalse(TPS.TPS_PREFERENCES["remote.prefs.recommended"])
+
+    def test_allows_time_for_manual_production_challenge(self):
+        self.assertEqual(TPS.TPS_PREFERENCES["testing.tps.oauthTimeoutMs"], 300000)
+
+    def test_production_preferences_and_child_environment_exclude_secrets(self):
+        preferences = TPS._prepare_tps_preferences(
+            {"fx_account": {"username": "qa@example.test"}},
+            fxa_ci_token=None,
+            debug=False,
+        )
+        self.assertNotIn("tps.fxa.bypassToken", preferences)
+
+        environment = TPS._prepare_tps_environment(
+            {
+                "TPS_FXA_USERNAME": "qa@example.test",
+                "TPS_FXA_PASSWORD": "secret",
+                "TPS_FXA_CI_TOKEN": "stage-token",
+                "UNRELATED": "retained",
+            },
+            "/tmp/source",
+            platform_name="linux",
+        )
+        self.assertEqual(environment["UNRELATED"], "retained")
+        self.assertNotIn("TPS_FXA_USERNAME", environment)
+        self.assertNotIn("TPS_FXA_PASSWORD", environment)
+        self.assertNotIn("TPS_FXA_CI_TOKEN", environment)
+
+
+class CleanupResourcesTests(unittest.TestCase):
+    def test_continues_profile_cleanup_and_always_stops_server(self):
+        events = []
+
+        class Profile:
+            def __init__(self, name, should_fail=False):
+                self.name = name
+                self.should_fail = should_fail
+
+            def cleanup(self):
+                events.append(f"cleanup:{self.name}")
+                if self.should_fail:
+                    raise RuntimeError("cleanup failed")
+
+        class Server:
+            def stop(self):
+                events.append("server:stop")
+
+        succeeded = TPS._cleanup_tps_resources(
+            [Profile("first", should_fail=True), Profile("second")], Server()
+        )
+
+        self.assertFalse(succeeded)
+        self.assertEqual(events, ["cleanup:first", "cleanup:second", "server:stop"])
+
+
+class AutofillActorTests(unittest.TestCase):
+    def test_two_step_disabled_submit_and_headless_visibility(self):
+        node = shutil.which("node")
+        self.assertIsNotNone(node, "Node.js is required for the actor test")
+        test_dir = os.path.dirname(__file__)
+        actor = os.path.join(
+            test_dir,
+            "..",
+            "..",
+            "services",
+            "sync",
+            "tps",
+            "extensions",
+            "tps",
+            "resource",
+            "actors",
+            "fxaAutofillChild.sys.mjs",
+        )
+        subprocess.run(
+            [node, os.path.join(test_dir, "test_fxa_autofill_actor.js"), actor],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- harden the TPS runner so it launches the privileged TPS extension through Marionette with one overall phase deadline
- support production FxA credentials from the parent environment while removing credentials and staging tokens from the Firefox child process
- automate the production two-step FxA form once per document and restrict submission to the active form
- skip remote cleanup for profiles that never completed a phase, while retaining unconditional local profile and server cleanup
- register focused Python and Node regression tests for the production credential boundary, actor behavior, cleanup policy, and timeout budget

## Why

The previous runner could not install the TPS add-on in the unsigned milestone build reliably and could repeat authentication during a slow challenge or after a failed phase. That made the real Floorp Notes cross-profile Sync validation non-deterministic and could trigger FxA rate limiting.

## Validation

- production FxA/Sync TPS: `test_floorp_notes.js` phase1, phase2, phase3, profile1 cleanup, and profile2 cleanup all passed; exit code 0
- `./mach python-test --subsuite tps`: 19 tests passed
- `./mach xpcshell-test services/sync/tests/unit/xpcshell-floorp-notes.toml`: 108/108 checks passed
- ESLint, Ruff, ruff-format, file-whitespace, file-perm, and python-sites checks passed
- `git diff --check` and credential/secret scan passed

Production credentials were sourced from macOS Keychain by the external test harness, never placed in process arguments, repository files, or retained evidence. Raw TPS logs and Notes payloads were deleted after the allowlisted summary was produced.
